### PR TITLE
Upraví zobrazenie pre carousel s prispievateľkami do Kníh roka

### DIFF
--- a/app/styles/knihy-roka.scss
+++ b/app/styles/knihy-roka.scss
@@ -178,6 +178,13 @@
   align-items: flex-start;
 }
 
+.swiper--prispievatelky {
+  .carousel__btn {
+    display: block !important;
+    top: 25% !important;
+  }
+}
+
 .card--annotation {
   background-color: _color(info, 100);
   border-bottom-left-radius: 0;

--- a/app/views/mixins/knihy-roka/prispievatelkyCarousel.pug
+++ b/app/views/mixins/knihy-roka/prispievatelkyCarousel.pug
@@ -9,19 +9,17 @@ mixin prispievatelkyCarousel(props = {})
     const {} = props;
 
     var swiperConfig = {
-      slidesPerView: 4,
-      slidesPerGroup: 2,
+      slidesPerView: 1,
       breakpoints: {
-        1024: {},
-        768: {
-          slidesPerView: 3,
-        },
         640: {
           slidesPerView: 2,
         },
-        480: {
-          slidesPerView: 1,
+        768: {
+          slidesPerView: 3,
         },
+        1024: {
+          slidesPerView: 4,
+        }
       },
     };
     swiperConfig = JSON.stringify(swiperConfig);


### PR DESCRIPTION
- správne nastavenie breakpointov
- forcne zobrazenie šípiek aj na mobile
- posunie šípky trošku vyššie, aby nezakrývali text

<img width="393" alt="Screenshot 2021-11-09 at 10 59 53" src="https://user-images.githubusercontent.com/2431529/140903303-402dc6ae-e1fc-4420-b156-7c7d4dbeb743.png">

https://www.wrike.com/open.htm?id=779770313