### PR TITLE
Tab tweaks

### DIFF
--- a/app/styles/modules/_tabs.scss
+++ b/app/styles/modules/_tabs.scss
@@ -94,7 +94,7 @@
         left: -1px;
         right: -1px;
 
-        height: _map-deep-get($tabs-card, 'default', margin-bottom) + _get-rem($default-border-radius * 2);
+        height: _map-deep-get($tabs-card, 'default', margin-bottom) + _get-rem($default-border-radius * 2) + _get-rem(3px);
         background-color: _map-deep-get($tabs-card, 'active', background-color);
         border: _map-deep-get($tabs-card, 'default', border);
         border-color: _map-deep-get($tabs-card, 'active', border-color);
@@ -120,6 +120,8 @@
   .tab-nav__item .tab-nav__content {
     border-radius: $default-border-radius;
   }
+
+  margin-bottom: -3px;
 }
 
 .tab-nav__content-wrap {

--- a/app/styles/utils/_config.scss
+++ b/app/styles/utils/_config.scss
@@ -1588,11 +1588,12 @@ $tabs-link: (
 
 $tabs-card: (
   default: (
+    transition: #{border $ease-200},
     border: 1px solid _color(grey, 400),
     padding: _get-space('small') _get-space('small'),
     font-size: _get-rem($font-size-medium),
     text-align: center,
-    margin-bottom: _get-space('small'),
+    margin-bottom: _get-space('small') + _get-rem(3px),
   ),
   active: (
     border-color: _color(bg, 500),
@@ -1601,6 +1602,8 @@ $tabs-card: (
     position: relative,
   ),
   focus: (
+    border-color: _color(grey, 500),
+    outline: none !important,
   ),
   disabled: (
   )


### PR DESCRIPTION
- no focus outline
- negative margin for dealing with scrollable tabs
- darker border on hover

https://www.wrike.com/open.htm?id=952039202