### PR TITLE
Better color contrast for grey text

### DIFF
--- a/app/styles/utils/_config.scss
+++ b/app/styles/utils/_config.scss
@@ -72,6 +72,7 @@ $color-palette: (
     700: #625d58,
     800: #595959,
     900: #474440,
+
   ),
   // colors
   yellow: (
@@ -142,7 +143,7 @@ $default-color-weights: (
 $color-presets: (
   white: $color-white,
   black: $color-black,
-  grey: _color(grey),
+  grey: _color(grey, 700),
   primary: _color(primary),
   primary-light: _color(primary, 400),
   primary-dark: _color(primary, 600),
@@ -443,9 +444,9 @@ $text-color-theme-400: _color(primary, 400);
 $text-color-theme-100: _color(primary, 100);
 
 $text-color-black: $color-black;
-$text-color-grey: _color(grey, 500);
+$text-color-grey: _color(grey, 700);
 $text-color-grey-light: _color(grey, 200);
-$text-color-grey-dark: _color(grey, 700);
+$text-color-grey-dark: _color(grey, 900);
 $text-color-semiblack: $color-semiblack;
 
 $text-color-white: $color-white;


### PR DESCRIPTION
According to https://dequeuniversity.com/rules/axe/4.4/color-contrast?utm_source=lighthouse&utm_medium=lr