### PR TITLE
Tooltips: A11y updates

### DIFF
--- a/app/scripts/modules/Tooltip.js
+++ b/app/scripts/modules/Tooltip.js
@@ -4,14 +4,27 @@ const defaultConfig = {
   animation: 'scale',
   arrow: true,
   interactive: true,
-  appendTo: () => document.body,
+  allowHTML: true,
+  // appendTo: () => document.body,
   delay: 150,
   content(reference) {
     // use title as a default tooltip content
-    const title = reference.getAttribute('data-tippy-content')
-      || reference.getAttribute('title');
+    const { tippyContent, html } = reference.dataset;
+
+    if (html) {
+      const template = document.querySelector(html);
+      reference.setAttribute('aria-describedby', html.replace('#', ''));
+
+      return template.innerHTML;
+    }
+
+    const title = tippyContent || reference.getAttribute('title');
+
     reference.removeAttribute('title');
-    reference.setAttribute('data-tippy-content', title);
+
+    const htmlStripped = title.replace(/<[^>]*>?/gm, '');
+    reference.setAttribute('aria-description', htmlStripped);
+
     return title;
   },
 };
@@ -45,16 +58,6 @@ export default class Tooltip {
     this.tooltips = targets.map(target => {
       const targetConfig = {};
       const { showOnCreate } = target.dataset;
-
-      // fetch html element to put in tooltip
-      const element = document.querySelector(target.dataset.html);
-
-      if (element) {
-        element.style.display = 'block';
-        targetConfig.content = element;
-      }
-
-      targetConfig.allowHTML = true;
 
       if (showOnCreate) {
         targetConfig.showOnCreate = true;

--- a/app/views/styleguide/tooltips.pug
+++ b/app/views/styleguide/tooltips.pug
@@ -40,25 +40,15 @@ block append content
             button.btn.btn--ghost(data-tooltip, title="This is tooltip text. <a href='#' class='link'>This is a link within tooltip.</a>") This button has tooltip with link
 
           #tooltip-light.hide
+            .card
+              .card__content.pb-none
+                h3 This is a content of hidden tooltip template
+                p You can put more html here
+                p <a href='#' class="link">This is a link within tooltip.</a>
+                button.btn.btn--primary.mb-none Test
+
           .bar__item
             button.btn.btn--ghost(data-tooltip, data-tippy-theme="light", data-html="#tooltip-light") Tooltip from html template
-
-              .card
-                .card__content
-                  h3 This is a content of hidden tooltip template
-                  p You can put more html here
-                  p <a href='#' class="link">This is a link within tooltip.</a>
-                  button.btn.btn-primary.mb-none Test
-              div.btn-group.btn-group--tab.btn-group--horizontal(data-tabs-container, role='tablist')
-                a.btn.btn--tab(href="#tooltip-tab1", data-tabs-item, role='tab') Tab 1
-                a.btn.btn--tab(href="#tooltip-tab2", data-tabs-item, role='tab') Tab 2
-              article.tabs
-                section.tab#tooltip-tab1
-                  h3 Tab 1
-                  p This is a content of tab 1
-                section.tab#tooltip-tab2
-                  h3 Tab 2
-                  p This is a content of tab 2
 
           .bar__item
             +icon('user').icon--large(data-tooltip, title="This is tooltip text on icon")


### PR DESCRIPTION
- add aria-describedby on html element referenced tooltips
- add aria-description on text tooltips (if it contains html, strip html from the description)
- voiceover was able to focus on interactive elements in open tooltips