### PR TITLE
Fix tooltip - set data-tippy-content attribute

### DIFF
--- a/app/scripts/modules/Tooltip.js
+++ b/app/scripts/modules/Tooltip.js
@@ -18,9 +18,10 @@ const defaultConfig = {
       return template.innerHTML;
     }
 
-    const title = tippyContent || reference.getAttribute('title') || '';
+    const title = reference.getAttribute('title') || tippyContent || '';
 
     reference.removeAttribute('title');
+    reference.setAttribute('data-tippy-content', title);
 
     const htmlStripped = title.replace(/<[^>]*>?/gm, '');
     reference.setAttribute('aria-description', htmlStripped);


### PR DESCRIPTION
For some reason during ajax calls it got removed.