### PR TITLE
Dotted text-decoration instead of bottom-border on emphasis element

### DIFF
--- a/app/styles/utils/_config.scss
+++ b/app/styles/utils/_config.scss
@@ -423,7 +423,6 @@ $em: (
   font-weight: var(--fw-semibold),
   color: $color-black,
   text-decoration: underline,
-  text-decoration-color: $color-black,
   text-decoration-thickness: 1px,
   text-decoration-style: dotted,
   text-underline-offset: 3px

--- a/app/styles/utils/_config.scss
+++ b/app/styles/utils/_config.scss
@@ -422,7 +422,11 @@ $em: (
   font-style: normal,
   font-weight: var(--fw-semibold),
   color: $color-black,
-  border-bottom: 1px dotted $color-black,
+  text-decoration: underline,
+  text-decoration-color: $color-black,
+  text-decoration-thickness: 1px,
+  text-decoration-style: dotted,
+  text-underline-offset: 3px
 );
 
 //---------------


### PR DESCRIPTION
![screenshot_2025-04-29_at_10 09 21_720](https://github.com/user-attachments/assets/2e5a4af7-397c-4b3c-b8f1-b8e8b948674d)

Reason for update: when using a bottom border, if the text spans multiple lines, it looks weird because the order is applied to the box and not to the lines of code.

This update will allow for a change:
<img width="205" alt="Screenshot 2025-04-29 at 11 46 35" src="https://github.com/user-attachments/assets/0395ead3-bd5f-4251-9074-f302c8ea11c3" />
