### PR TITLE
Carousel fade: larger width of the pseudo-elements

### DIFF
--- a/app/styles/utils/_config.scss
+++ b/app/styles/utils/_config.scss
@@ -1712,7 +1712,7 @@ $carousel: (
     offsetV: 25%,
   ),
   fade: (
-    size: 800px,
+    size: 1800px,
     gradient: (rgba(_color('bg'), 0), rgba(_color('bg'), 0.7) 40px, rgba(_color('bg'), 1) 300px),
     gradient-white: (rgba($color-white, 0), rgba($color-white, 0.7) 40px, rgba($color-white, 1) 300px),
   ),


### PR DESCRIPTION
Fix to support ultrawide displays

https://www.wrike.com/open.htm?id=1611188493