### PR TITLE
Fix: optipng-bin postinstall pre Apple Silicon (ARM64)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,6 +34,9 @@ services:
       # The .tmp and tmp directories are created by gulp during build
       # Mounting them can cause EBUSY errors with concurrent access
 
+      # Scripts (postinstall helpers)
+      - ../scripts:/app/scripts:ro
+
       # Config files (read-only)
       - ../.babelrc:/app/.babelrc:ro
       - ../.browserslistrc:/app/.browserslistrc:ro

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "node": ">=18.2.0"
   },
   "scripts": {
+    "postinstall": "node scripts/fix-optipng.js",
     "prepare": "gulp prepare --openssl-legacy-provider",
     "build": "gulp build --openssl-legacy-provider --mode=production",
     "serve": "gulp serve --openssl-legacy-provider",

--- a/scripts/fix-optipng.js
+++ b/scripts/fix-optipng.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Postinstall fix for optipng-bin on ARM64 (Apple Silicon + Alpine Docker).
+// The npm package optipng-bin ships an x86 binary and fails to compile from
+// source on aarch64-musl. The Docker image already has system optipng via apk.
+// This script wires the system binary into the expected vendor path so
+// imagemin-optipng can find it without errors.
+
+'use strict';
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+
+function systemOptipngPath() {
+  try {
+    return execSync('which optipng 2>/dev/null', { encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function run() {
+  const systemBin = systemOptipngPath();
+  if (!systemBin) {
+    return; // Not in Docker or system optipng not present – skip silently.
+  }
+
+  const pkgDir = path.join(root, 'node_modules', 'optipng-bin');
+  const vendorDir = path.join(pkgDir, 'vendor');
+  const vendorBin = path.join(vendorDir, 'optipng');
+
+  if (fs.existsSync(vendorBin)) {
+    return; // Already set up.
+  }
+
+  fs.mkdirSync(vendorDir, { recursive: true });
+  fs.copyFileSync(systemBin, vendorBin);
+  fs.chmodSync(vendorBin, 0o755);
+
+  fs.writeFileSync(
+    path.join(pkgDir, 'index.js'),
+    `'use strict';\nconst path = require('path');\nmodule.exports = path.join(__dirname, 'vendor', 'optipng');\n`
+  );
+
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'optipng-bin', version: '7.0.1', main: 'index.js' }, null, 2) + '\n'
+  );
+
+  console.log('optipng-bin: linked system optipng binary (' + systemBin + ')');
+}
+
+run();


### PR DESCRIPTION
**`optipng-bin`** zlyhával počas `yarn install` na Apple Silicon pretože npm balíček dodáva x86 binárku a kompilácia zo zdrojov na aarch64-musl tiež nevychádza. Docker image má **systémový `optipng` cez `apk`** — postinstall skript ho jednoducho prepojí tam, kde ho `imagemin-optipng` hľadá.

## Detaily
- Pridaný **`scripts/fix-optipng.js`** – po `yarn install` skopíruje `/usr/bin/optipng` do `node_modules/optipng-bin/vendor/optipng` a vytvorí minimálny wrapper; na strojoch bez systémového optipng sa potichu preskočí
- **`package.json`** – pridaný `"postinstall": "node scripts/fix-optipng.js"`
- **`docker/docker-compose.yml`** – namountovaný `scripts/` adresár do kontajnera (read-only)