### PR TITLE
Fix: dark mode regresie — borders vo formulároch a fade v karuseloch

### DIFF
--- a/app/styles/base/_globals.scss
+++ b/app/styles/base/_globals.scss
@@ -73,7 +73,7 @@
   // === Forms ===
   --#{$prefix}form-bg: #{_color(grey, 50)};
   --#{$prefix}form-text: #{$color-black};
-  --#{$prefix}form-border: #{_color(grey, 200)};
+  --#{$prefix}form-border: #{_color(grey, 400)};
   --#{$prefix}form-placeholder: #{_color(grey, 400)};
   --#{$prefix}form-error-border: #{_color(error, 600)};
   --#{$prefix}form-error-text: #{$color-black};

--- a/app/styles/base/_globals.scss
+++ b/app/styles/base/_globals.scss
@@ -292,7 +292,7 @@ html[data-theme='dark'],
   --#{$prefix}megamenu-overlay-bg: rgba(255, 255, 255, 0.1);
 
   // === Carousel ===
-  --#{$prefix}fade-color: var(--#{$prefix}surface-primary);
+  --#{$prefix}fade-color: var(--#{$prefix}surface-secondary);
 
   // === Background Colors ===
   --#{$prefix}bg-blue: var(--#{$prefix}state-info-bg);

--- a/app/styles/utils/_config.scss
+++ b/app/styles/utils/_config.scss
@@ -1768,9 +1768,9 @@ $carousel: (
       rgb(from var(--#{$prefix}fade-color, #{_color('bg')}) r g b / 1) 300px
     ),
     gradient-white: (
-      rgb(from var(--#{$prefix}fade-color, #{$color-white}) r g b / 0),
-      rgb(from var(--#{$prefix}fade-color, #{$color-white}) r g b / 0.7) 40px,
-      rgb(from var(--#{$prefix}fade-color, #{$color-white}) r g b / 1) 300px
+      rgb(from var(--#{$prefix}surface-primary) r g b / 0),
+      rgb(from var(--#{$prefix}surface-primary) r g b / 0.7) 40px,
+      rgb(from var(--#{$prefix}surface-primary) r g b / 1) 300px
     ),
     gradient-fallback: (rgba(_color('bg'), 0), rgba(_color('bg'), 0.7) 40px, rgba(_color('bg'), 1) 300px),
     gradient-white-fallback: (rgba($color-white, 0), rgba($color-white, 0.7) 40px, rgba($color-white, 1) 300px),
@@ -1783,9 +1783,9 @@ $carousel: (
       rgb(from var(--#{$prefix}fade-color, #{_color('bg')}) r g b / 1) 20px
     ),
     gradient-white: (
-      rgb(from var(--#{$prefix}fade-color, #{$color-white}) r g b / 0),
-      rgb(from var(--#{$prefix}fade-color, #{$color-white}) r g b / 0.7) 20px,
-      rgb(from var(--#{$prefix}fade-color, #{$color-white}) r g b / 1) 20px
+      rgb(from var(--#{$prefix}surface-primary) r g b / 0),
+      rgb(from var(--#{$prefix}surface-primary) r g b / 0.7) 20px,
+      rgb(from var(--#{$prefix}surface-primary) r g b / 1) 20px
     ),
     gradient-fallback: (rgba(_color('bg'), 0), rgba(_color('bg'), 0.7) 20px, rgba(_color('bg'), 1) 20px),
     gradient-white-fallback: (rgba($color-white, 0), rgba($color-white, 0.7) 20px, rgba($color-white, 1) 20px),

--- a/app/views/carousels-showcase.pug
+++ b/app/views/carousels-showcase.pug
@@ -1,0 +1,121 @@
+extends layouts/_default
+
+include ./mixins/booksCarouselRecommended
+include ./mixins/libraryCarousel
+include ./mixins/faIcon
+include ./mixins/icon
+
+block opts
+    - var pageTitle = 'Carousels showcase'
+    - var headerWarningActive = false
+
+block content
+
+  main
+    section.section.section--white
+      .wrapper-main
+        h1.mb-tiny Carousels
+        p.text-color-grey.mb-none Prehľad variantov karuselov v reálnom layoute. Prepnite tému (svetlá/tmavá) a pozrite, ako sa jednotlivé varianty prispôsobujú.
+
+    //- --------------------------------------------------
+    //- FADE OUTSIDE (default) — fades to the section background
+    section.section.section--secondary
+      .wrapper-main
+        h2.mb-tiny .carousel--fade-outside
+        p.text-color-grey.mb-small Default fade (large 1800px fade zones outside the container). Fades to the surrounding section background — here on the default (secondary) surface.
+        +booksCarouselRecommended({ads: false, collections: false}).carousel--fade-outside
+
+    //- --------------------------------------------------
+    //- FADE OUTSIDE WHITE — fades to the primary (white/dark) surface
+    section.section.section--white
+      .wrapper-main
+        h2.mb-tiny .carousel--fade-outside.carousel--fade-outside-white
+        p.text-color-grey.mb-small Fade-outside tuned for primary-surface contexts (white cards in light mode, dark surface in dark mode).
+        +booksCarouselRecommended({ads: false, collections: false}).carousel--fade-outside.carousel--fade-outside-white
+
+    //- --------------------------------------------------
+    //- FADE INSIDE (default)
+    section.section.section--secondary
+      .wrapper-main
+        h2.mb-tiny .carousel--fade-inside
+        p.text-color-grey.mb-small Compact 20px fade applied inside the container, clipping the last slide edge.
+        +booksCarouselRecommended({ads: false, collections: false, cartButton: true}).carousel--fade-inside
+
+    //- --------------------------------------------------
+    //- FADE INSIDE WHITE
+    section.section.section--white
+      .wrapper-main
+        h2.mb-tiny .carousel--fade-inside.carousel--fade-inside-white
+        p.text-color-grey.mb-small Compact fade for primary-surface (white/dark) backgrounds.
+        +booksCarouselRecommended({ads: false, collections: false, cartButton: true}).carousel--fade-inside.carousel--fade-inside-white
+
+    //- --------------------------------------------------
+    //- FADE INACTIVE + DISABLE INACTIVE — banner carousel
+    section.section.section--secondary
+      .wrapper-main
+        h2.mb-tiny .carousel--fade-inactive.carousel--disable-inactive
+        p.text-color-grey.mb-small Inactive slides are dimmed (opacity 0.5) and not clickable. Typical banner usage.
+        include ./modules/carousel-banner
+
+    //- --------------------------------------------------
+    //- FAN — collection carousel
+    section.section.section--white
+      .wrapper-main
+        h2.mb-tiny .carousel--fan
+        p.text-color-grey.mb-small Fanning animation. Used for collection promos.
+        include ./modules/collection-carousel
+
+    //- --------------------------------------------------
+    //- CAROUSEL CARDS — info cards with icon + text
+    section.section.section--white.section--overflow
+      .wrapper-main
+        h2.mb-tiny .carousel-cards (with fade-outside-white)
+        p.text-color-grey.mb-small Horizontal info-card slider. Used in the homepage footer (USPs).
+        -
+          var swiperCardsContent = [
+            { icon: 'footer-tradition', text: 'Máme skoro 30-ročnú tradíciu predaja kníh' },
+            { icon: 'footer-shipping', text: 'Ponúkame vyše 20 000 titulov na sklade' },
+            { icon: 'footer-stores', text: '10 kníhkupectiev po celom Slovensku' },
+            { icon: 'footer-package', text: 'Sme 3-násobný MasterCard Obchodník roka' },
+            { icon: 'footer-events', text: 'Organizujeme desiatky besied s autormi' },
+            { icon: 'footer-positive', text: 'Podporujeme čítanie s porozumením' },
+          ];
+          var swiperCardsConfig = JSON.stringify({
+            slidesPerView: 'auto',
+            slidesPerGroup: 1,
+            spaceBetween: 20,
+            centeredSlides: true,
+            loop: true,
+          });
+        .carousel.carousel--fade-outside.carousel--fade-outside-white.carousel-cards
+          .swiper(data-swiper-options=swiperCardsConfig)
+            .swiper-wrapper
+              each item in swiperCardsContent
+                .swiper-slide.carousel-cards__item
+                  .card.card--well
+                    .card__content
+                      .bar.mb-none
+                        .bar__item.bar__item--shrinkable
+                          +icon(item.icon, 'text-color-grey')
+                        .bar__item.bar__item--fill
+                          p.text-medium= item.text
+            button.btn.btn--carousel.btn--large.btn--equal.carousel__btn.carousel__btn--prev
+              +faIcon('arrow-left').fa-2x
+            button.btn.btn--carousel.btn--large.btn--equal.carousel__btn.carousel__btn--next
+              +faIcon('arrow-right').fa-2x
+
+    //- --------------------------------------------------
+    //- LIBRARY CAROUSEL — carousel of cards (library list items)
+    section.section.section--secondary
+      .wrapper-main
+        h2.mb-tiny .carousel--fade-outside (cards inside)
+        p.text-color-grey.mb-small Generic card slides. Used for the user's library listing.
+        +libraryCarousel
+
+    //- --------------------------------------------------
+    //- PLAIN — no modifier
+    section.section.section--white
+      .wrapper-main
+        h2.mb-tiny .carousel (no modifier)
+        p.text-color-grey.mb-small Plain carousel with no fade/animation modifier — slides simply scroll.
+        +booksCarouselRecommended({ads: false, collections: false, productInfo: false})

--- a/app/views/data/sitemap.yaml
+++ b/app/views/data/sitemap.yaml
@@ -45,6 +45,8 @@ sitemap:
         href: section-headers
       - title: Newsletter Landing Page
         href: newsletter
+      - title: Carousels showcase
+        href: carousels-showcase
   - title: Campaigns
     contents:
       - title: Knižné putovanie 2024


### PR DESCRIPTION
Dve regresie, ktoré pricestovali so zavedením CSS premenných pre dark mode.

## 1. Kontrast borderu vo formulároch (light mode)

`--form-border` sa v `:root` omylom nastavil na `grey-200` (#e5e5e5) namiesto pôvodnej hodnoty `grey-400` (#bcbcba). Na svetlom pozadí formulárového poľa (`grey-50` = #fafafa) bol rozdiel takmer neviditeľný — dizajnér nahlásil stratu kontrastu.

Dark mode nie je dotknutý — ten si `--form-border` prepisuje vlastnou hodnotou cez `var(--border-default)`.

### Detaily
- **`app/styles/base/_globals.scss`** – `--form-border` v `:root` zmenený z `_color(grey, 200)` na `_color(grey, 400)`

## 2. Farby fade efektov v karuseloch (light aj dark mode)

Dva súvisiace bugy okolo `--fade-color`:

- **`.carousel--fade-outside-white` v light mode zanikalo do béžovej namiesto bielej.** `gradient-white` používal `var(--fade-color, $color-white)` s fallbackom na bielu, ale po dark mode PR sa `--fade-color` nastavil globálne v `:root` na `_color(bg)`, takže fallback sa nikdy nepoužil.
- **`.carousel--fade-outside` (default) v dark mode zanikalo do nesprávneho odtieňa.** `--fade-color` v dark mode smerovalo na `--surface-primary` (#0D0D0C), ale default fade sa zvyčajne sádza na `section--secondary` (`--surface-secondary` = #252321) — vznikla tmavšia „diera" na svetlejšom tmavom pozadí.

### Detaily
- **`app/styles/base/_globals.scss`** – `--fade-color` v dark mode prepnutý z `--surface-primary` na `--surface-secondary`
- **`app/styles/utils/_config.scss`** – `gradient-white` variant referuje priamo `--surface-primary` (v light mode = biela, v dark mode = primary tmavý povrch) namiesto cez `--fade-color`
- **`app/views/carousels-showcase.pug`** + **`sitemap.yaml`** – nová ukážková stránka so všetkými variantami karuselov v reálnom layoute pre vizuálnu kontrolu v oboch režimoch