### PR TITLE
Migrácia Swiper na v12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ bower_components
 .idea
 app/images/lightgallery
 app/fonts/lightgallery
+app/styles/vendors/swiper
 .DS_Store
 config.codekit3
 yarn-error.log

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1,6 +1,6 @@
 // VENDORS
 @import './../../node_modules/normalize.css/normalize';
-@import './../../node_modules/swiper/swiper-bundle';
+@import 'vendors/swiper/swiper-bundle';
 
 // UTILS
 @import './../../node_modules/bootstrap/scss/functions';

--- a/app/views/carousels-showcase.pug
+++ b/app/views/carousels-showcase.pug
@@ -50,6 +50,20 @@ block content
         +booksCarouselRecommended({ads: false, collections: false, cartButton: true}).carousel--fade-inside.carousel--fade-inside-white
 
     //- --------------------------------------------------
+    //- FADE CUSTOM COLORS — demonstrates the --ms-fade-color override
+    section.section.section--secondary
+      .wrapper-main
+        h2.mb-tiny .carousel--fade-outside (custom --ms-fade-color)
+        p.text-color-grey.mb-small The fade gradient reads from <code>--ms-fade-color</code>. Set it inline (or on any ancestor) to tint the edges to any color.
+        +booksCarouselRecommended({ads: false, collections: false, productInfo: false})(style="--ms-fade-color: #9967a7;").carousel--fade-outside
+
+    section.section.section--secondary
+      .wrapper-main
+        h2.mb-tiny .carousel--fade-inside (custom --ms-fade-color)
+        p.text-color-grey.mb-small Same variable works for the compact inside fade — useful for callouts embedded in colored blocks.
+        +booksCarouselRecommended({ads: false, collections: false, cartButton: true})(style="--ms-fade-color: #fcc34c;").carousel--fade-inside
+
+    //- --------------------------------------------------
     //- FADE INACTIVE + DISABLE INACTIVE — banner carousel
     section.section.section--secondary
       .wrapper-main

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 const gulp = require('gulp');
 const HubRegistry = require('gulp-hub');
 
@@ -12,6 +14,17 @@ gulp.task('prepare', done => {
   gulp
     .src('./node_modules/lightgallery.js/src/fonts/**')
     .pipe(gulp.dest('./app/fonts/lightgallery/'));
+
+  // Swiper v12 ships CSS-only styles that use modern CSS nesting.
+  // `button&` isn't valid Sass syntax, so rewrite it to `&:is(button)`
+  // before saving as a Sass partial that main.scss can @import.
+  const swiperSrc = fs.readFileSync(
+    './node_modules/swiper/swiper-bundle.css',
+    'utf8'
+  );
+  const swiperDest = './app/styles/vendors/swiper/_swiper-bundle.scss';
+  fs.mkdirSync(path.dirname(swiperDest), { recursive: true });
+  fs.writeFileSync(swiperDest, swiperSrc.replace(/button&/g, '&:is(button)'));
 
   done();
 });

--- a/light.config.js
+++ b/light.config.js
@@ -113,7 +113,29 @@ module.exports = (paths, config) => {
       },
       scripts: {
         module: {
-          rules: [],
+          rules: [
+            {
+              test: /\.mjs$/,
+              include: /node_modules[\\/]swiper/,
+              type: 'javascript/auto',
+              use: {
+                loader: 'babel-loader',
+                options: {
+                  babelrc: false,
+                  presets: [
+                    ['@babel/preset-env', {
+                      modules: false,
+                      loose: true,
+                      include: [
+                        '@babel/plugin-transform-optional-chaining',
+                        '@babel/plugin-transform-nullish-coalescing-operator',
+                      ],
+                    }],
+                  ],
+                },
+              },
+            },
+          ],
         }
       },
       serve: {


### PR DESCRIPTION
**Upgrade Swiperu na v12** (PR #612) rozbil build — v12 odstránil `.scss` zdroje a jeho `.mjs` súbory používajú moderný JS syntax, ktorý webpack 4 parser nezvláda. Tento PR dopĺňa **migračné kroky** tak, aby všetky Swiper štýly zostali zabundlované v `main.css` (bez potreby extra `<link>` v produktových stránkach) a aby webpack vedel parsovať Swiper `.mjs` nezávisle od browserslist targetov.

## Detaily

- **`gulpfile.js` prepare task**: kopíruje `swiper-bundle.css` z `node_modules`, prepisuje jediný problémový `button&` CSS-nesting token na Sass-kompatibilný `&:is(button)` a ukladá ako `_swiper-bundle.scss` partial. Spúšťa sa automaticky cez yarn `prepare` lifecycle, takže pri upgrade Swiperu sa partial **zregeneruje bez manuálneho kroku**.
- **`main.scss`**: importuje vygenerovaný partial namiesto odstráneného `node_modules/swiper/swiper-bundle.scss`.
- **`light.config.js`**: pridané pravidlo pre **babel-loader** na `swiper/**/*.mjs`, ktoré si vynucuje transformáciu `?.` a `??` nezávisle od browserslist targetov — webpack 4 inak moderný output nezvládne rozparsovať.
- **`carousels-showcase.pug`**: pridané dva príklady demonštrujúce už existujúce override premennej **`--ms-fade-color`** (fialový a žltý tint).
- **`.gitignore`**: ignorovaný vygenerovaný adresár `app/styles/vendors/swiper/`.