### PR TITLE
MCP: get_setup tool + two-mode (external/internal) skeleton

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "martinus-styleguide": {
+      "command": "docker",
+      "args": ["exec", "-i", "martinus-styleguide-mcp", "node", "/mcp-server/src/index.js"]
+    }
+  }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -87,6 +87,11 @@ services:
     # Environment
     environment:
       - NODE_ENV=production
+      # Enables internal mode — exposes filesystem-backed tools (raw Pug/SCSS
+      # source, mixin inspection). When unset (e.g. npx distribution), the
+      # server runs in external mode and only hosted-artifact tools are
+      # available.
+      - MARTINUS_STYLEGUIDE_APP_DIR=/app/app
 
     # Keep container running
     stdin_open: true

--- a/docs/guides/mcp-audit.md
+++ b/docs/guides/mcp-audit.md
@@ -4,6 +4,10 @@
 
 Tento dokument je živý audit MCP servera styleguide (`mcp-server/src/index.js`) a plán jeho prepracovania pre nový primárny cieľ: **externé projekty (napr. Lovable), ktoré chcú získať Martinus styling bez toho, aby mali checkout tohto repozitára**.
 
+> **Tracking:** [Wrike task — MCP pre frontendové nástroje (Styleguide)](https://www.wrike.com/open.htm?id=4434230510)
+>
+> **Workflow:** po každom novom PR v rámci tejto úlohy pridať nový `<b>Progres YYYY-MM-DD — <scope></b>` blok do popisu Wrike tasku (pattern viď existujúce Progres bloky). Blok obsahuje čo sa spravilo a link na PR. Wrike API pozná: description cez `mcp__wrike__wrike_update_task` (pozor, pri podobných zmenách `+` v texte sa URL-dekóduje na medzeru — escapovať cez `&#43;` alebo preformulovať).
+
 ## 1. Východiskový stav
 
 Aktuálny MCP server ponúka 8 nástrojov nad lokálnym adresárom `/app/app` (read-only mount v Dockeri):

--- a/docs/guides/mcp-audit.md
+++ b/docs/guides/mcp-audit.md
@@ -37,6 +37,7 @@ Distribúcia: Docker kontajner `martinus-styleguide-mcp`, Claude Code sa pripáj
 - **Len `main` bundle.** Ostatné (`banners`, `campaigns`, `gallery`, `xmas`, ...) sú pre špecifické use-casy a nie sú súčasťou API.
 - **Zdroj pravdy = hostovaná verzia.** Base URL: `https://mrtns.sk/assets/martinus/lb/`. Manifest: `https://mrtns.sk/assets/martinus/lb/rev-manifest.json` (overene publicly accessible). MCP ho fetchuje pri štarte + krátke TTL cache.
 - **Vždy latest.** Žiadny pinning verzií. Hashe sa prekladajú z hostovaného manifestu, nie baked-in.
+- **Cache-busting cez query-string, nie hashed filename.** MCP emituje URL v tvare `styles/main.css?v=<hash>`, nie `styles/main.<hash>.css`. Dôvod: konzument si HTML snippet pastne do svojho projektu. Pri ďalšom styleguide buildi sa hash zmení — hashed-filename varianta by spôsobila, že staré embeds prestanú fungovať (súbor s pôvodným hashom ostáva na hosting, ale consumer nevie, že má URL preložiť). Stabilná cesta + query param rieši cache-busting prehliadača a zároveň drží staré embeds funkčné (servujú latest). Overené: hosting obslúži aj unversioned (`main.css`) aj hashed (`main.<hash>.css`) cesty súbežne.
 - **Thin fetch client, build emituje artefakty.** MCP nemá Pug, nemá Sass, nemá runtime kompiláciu. Všetko čo konzument potrebuje je vopred vypočítané v `./build.sh` a deployované. MCP len fetchuje a kombinuje. Engine-agnostický z konštrukcie — budúca výmena Pugu znamená výmenu build tasku, MCP ostáva rovnaký.
 - **Ikony = Font Awesome Pro 6.** Externé API neodhaľuje `app/icons_/`. Oficiálna cesta: FA notácia (`<i class="far fa-heart"></i>`) s curated subsetom z `app/views/styleguide/data/font-awesome-subset.yaml` (5 štýlov: regular, brands, solid, duotone, kit/martinus). Martinus má unlimited FA Pro licenciu ktorá pokrýva distribúciu hostovaného bundlu — MCP môže servírovať `scripts/font-awesome.js` z `mrtns.sk` aj cudzím projektom. Kit ikony (`fak-martinus`, `fak-owl`, `fak-owl-plus`) sú Martinus-owned custom a sú zabalené priamo v tomto bundli.
 
@@ -136,7 +137,7 @@ Cieľová sada (názvy finálne až po review):
 
 | Nástroj | Účel | Zdroj |
 |---|---|---|
-| `get_setup` | Vráti `<link>`/`<script>` tagy s resolved hashmi + font preconnects, pre main bundle. Voliteľný `with: ["font-awesome"]` pridá FA JS `<script>` s hashom z manifestu. | `rev-manifest.json` |
+| `get_setup` | Vráti `<link>`/`<script>` tagy pre main bundle. URL tvar: `styles/main.css?v=<hash>` (query-string cache-busting, viď §2). Font Awesome Pro vždy included (rozhodnutie z implementácie — opt-in API pridalo zbytočnú friction). Parameter `language: "sk" \| "cz"` pre i18n interaktívnych modulov. | `rev-manifest.json` |
 | `get_starter_template` | Minimálny HTML skeleton (doctype, head, body s wrapper class) napojený na main bundle. | `rev-manifest.json` |
 | `list_components` | Lista konzumovateľných komponentov. | `mcp-manifest.json` |
 | `get_component` | Kompilovaný HTML fragment s resolvovaným `assetsPrefix`. Response obsahuje `requires` array (napr. `["font-awesome"]` ak komponent používa ikony). | `components/<name>.html` + `mcp-manifest.json` |
@@ -221,6 +222,8 @@ Klasifikácia všetkých 27 modulov v `app/scripts/modules/`:
 
 | Téma | Rozhodnutie |
 |---|---|
+| Cache-busting URL formát | **`path?v=<hash>`** namiesto `path.<hash>.ext`. Stabilná cesta, embeds prežijú ďalší build. Viď §2. |
+| FA inclusion policy | **Vždy included** v `get_setup` (nie opt-in cez `with`). Pôvodný audit §5 navrhoval opt-in kvôli bloat, ale v praxi takmer každý komponent používa FA ikony (dropdown šípky, close tlačidlá, form indicators) a chýbajúce ikony pri minimalistickom setup-e = horší DX. |
 | Tokens formát | **Nested JSON** (`{ color: { primary: "#...", ... }, spacing: {...}, typography: {...} }`) |
 | npm scope | **`@martinus/styleguide-mcp`** |
 | Interné nástroje | **Two-mode MCP** — viď §6.1 |
@@ -259,8 +262,12 @@ Docker-based flow ostáva — `./mcp.sh` nastaví `APP_DIR` a spustí kontajner 
 
 Po odsúhlasení tohto dokumentu:
 
-1. **Fáza 3** najprv — inventár JS modulov + rozhodnutia z otázok 1-6. (Malé množstvo user inputu, veľký dopad na design.)
-2. **Fáza 2 implementácia** — nástroje s najväčšou hodnotou ako prvé: `get_setup`, `get_starter_template`, `get_component` (s mockovaným build stepom na začiatku). Následne `get_tokens`, `list/get_icon`, zvyšok.
-3. **Oprava existujúcich bugov** (Sekcia 3.6, 3.8) — v aktuálnej Docker verzii aj pre uistenie, že interní devs neblokujú na nich.
-4. **Build-time component emitter** v `./build.sh` — nová Gulp task.
-5. **Fáza 4** — npm publish po stabilizácii API.
+1. ✅ **Fáza 3** — inventár JS modulov + rozhodnutia z otázok 1-6. Viď §3.8 a §6.
+2. **Fáza 2 implementácia** — nástroje s najväčšou hodnotou ako prvé:
+   - ✅ `get_setup` — emituje `head`/`bodyEnd`/`htmlClasses`, URLs s `?v=<hash>` cache-bustingom. Two-mode skeleton (`MARTINUS_STYLEGUIDE_APP_DIR` env var) + fetch-client s TTL cache založené.
+   - 🔲 `get_starter_template` — triviálny follow-up (ten istý manifest, HTML skeleton okolo `get_setup`).
+   - 🔲 `get_component` (potrebuje build emitter, krok 4).
+   - 🔲 `get_tokens`, `list_icons` (FA subset), `get_icon`, `find_class`, `list_js_behaviors`, `get_js_behavior`.
+3. ✅ **Oprava existujúcich bugov** (Sekcia 3.6, 3.8) — commit `594c4110`.
+4. 🔲 **Build-time component emitter** v `./build.sh` — nová Gulp task pre `dist/components/*.html`, `dist/tokens.json`, `dist/class-index.json`, `dist/icons.json`, `dist/mcp-manifest.json`.
+5. 🔲 **Fáza 4** — npm publish po stabilizácii API.

--- a/mcp-server/src/index.js
+++ b/mcp-server/src/index.js
@@ -12,7 +12,16 @@ import { join, relative, extname } from 'path';
 import * as cheerio from 'cheerio';
 import yaml from 'js-yaml';
 
-const APP_DIR = '/app/app';
+// External mode (default): APP_DIR unset → filesystem tools are hidden and the
+// server serves only hosted-artifact tools (suitable for npx distribution).
+// Internal mode: APP_DIR points at a local styleguide checkout (Docker mount
+// or a contributor's working copy) and filesystem tools become available.
+const APP_DIR = process.env.MARTINUS_STYLEGUIDE_APP_DIR || null;
+
+const ASSETS_BASE_URL = (process.env.MARTINUS_STYLEGUIDE_ASSETS_URL
+  || 'https://mrtns.sk/assets/martinus/lb/').replace(/\/?$/, '/');
+const MANIFEST_URL = `${ASSETS_BASE_URL}rev-manifest.json`;
+const MANIFEST_CACHE_TTL_MS = 5 * 60 * 1000;
 
 /**
  * MCP Server for Martinus Styleguide
@@ -35,9 +44,102 @@ class StyleguideServer {
     this.componentIndex = null;
     this.scssIndex = null;
     this.pugMixinIndex = null;
+    this.manifestCache = null;
 
     this.setupHandlers();
     this.setupErrorHandling();
+  }
+
+  isInternalMode() {
+    return Boolean(APP_DIR);
+  }
+
+  requireInternalMode(toolName) {
+    if (!this.isInternalMode()) {
+      throw new Error(
+        `Tool "${toolName}" requires internal mode. Set the `
+        + 'MARTINUS_STYLEGUIDE_APP_DIR environment variable to a styleguide '
+        + 'checkout path to enable filesystem-backed tools.'
+      );
+    }
+  }
+
+  async fetchManifest() {
+    const now = Date.now();
+    if (this.manifestCache && (now - this.manifestCache.fetchedAt) < MANIFEST_CACHE_TTL_MS) {
+      return this.manifestCache.data;
+    }
+    const res = await fetch(MANIFEST_URL);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch rev-manifest.json (${res.status} ${res.statusText}) from ${MANIFEST_URL}`);
+    }
+    const data = await res.json();
+    this.manifestCache = { data, fetchedAt: now };
+    return data;
+  }
+
+  resolveAsset(manifest, logicalPath) {
+    const hashed = manifest[logicalPath];
+    if (!hashed) {
+      throw new Error(`Asset "${logicalPath}" not present in rev-manifest.json. Available keys: ${Object.keys(manifest).sort().join(', ')}`);
+    }
+    // Query-string cache-busting instead of hashed filenames: consumers embed
+    // these URLs in their HTML, and hashed filenames stop resolving after the
+    // next styleguide rebuild. Stable path + ?v=<hash> keeps old embeds alive
+    // while still busting browser cache on new hashes. Hosting serves both.
+    const hashMatch = hashed.match(/\.([a-f0-9]+)\.[^.]+$/);
+    if (!hashMatch) {
+      return `${ASSETS_BASE_URL}${logicalPath}`;
+    }
+    return `${ASSETS_BASE_URL}${logicalPath}?v=${hashMatch[1]}`;
+  }
+
+  async getSetup(args) {
+    const language = args.language ?? 'sk';
+    if (!['sk', 'cz'].includes(language)) {
+      throw new Error(`Invalid language "${language}". Use "sk" or "cz".`);
+    }
+
+    const manifest = await this.fetchManifest();
+    const tabacCssUrl = this.resolveAsset(manifest, 'fonts/Tabac-Sans/style.css');
+    const mainCssUrl = this.resolveAsset(manifest, 'styles/main.css');
+    const vendorJsUrl = this.resolveAsset(manifest, 'scripts/vendor.js');
+    const mainJsUrl = this.resolveAsset(manifest, 'scripts/main.js');
+    const faJsUrl = this.resolveAsset(manifest, 'scripts/font-awesome.js');
+
+    const head = [
+      `<link rel="stylesheet" href="${tabacCssUrl}">`,
+      `<link rel="stylesheet" href="${mainCssUrl}">`,
+    ].join('\n');
+
+    const bodyEnd = [
+      `<script>window.myApp = window.myApp || {}; window.myApp.selectLanguage = ${JSON.stringify(language)};</script>`,
+      `<script src="${vendorJsUrl}"></script>`,
+      `<script src="${mainJsUrl}"></script>`,
+      `<script src="${faJsUrl}"></script>`,
+    ].join('\n');
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            htmlClasses: ['fonts-loaded'],
+            head,
+            bodyEnd,
+            language,
+            assetsBaseUrl: ASSETS_BASE_URL,
+            bundleVersions: {
+              'styles/main.css': manifest['styles/main.css'],
+              'scripts/main.js': manifest['scripts/main.js'],
+              'scripts/vendor.js': manifest['scripts/vendor.js'],
+              'scripts/font-awesome.js': manifest['scripts/font-awesome.js'],
+              'fonts/Tabac-Sans/style.css': manifest['fonts/Tabac-Sans/style.css'],
+            },
+          }, null, 2),
+        },
+      ],
+    };
   }
 
   setupErrorHandling() {
@@ -52,11 +154,26 @@ class StyleguideServer {
   }
 
   setupHandlers() {
-    // List available tools
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: [
-        {
-          name: 'list_components',
+    const externalTools = [
+      {
+        name: 'get_setup',
+        description: 'Returns asset setup (stylesheet links, script tags, required <html> classes) for embedding the Martinus styleguide in an external project. Fetches the live rev-manifest.json from the hosted styleguide so asset URLs always point at the current hashed files. Response contains `head` (inject into <head>), `bodyEnd` (inject before </body>), and `htmlClasses` (add to the <html> element). Font Awesome Pro is always included. Use this once per project to wire up the base bundle.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            language: {
+              type: 'string',
+              enum: ['sk', 'cz'],
+              description: 'UI language for i18n-aware interactive modules (Select, Autocomplete). Default: "sk".',
+            },
+          },
+        },
+      },
+    ];
+
+    const internalTools = [
+      {
+        name: 'list_components',
           description: 'List all UI components/modules in the styleguide with their file locations',
           inputSchema: {
             type: 'object',
@@ -154,15 +271,24 @@ class StyleguideServer {
             },
           },
         },
-      ],
+    ];
+
+    const internalToolNames = new Set(internalTools.map(t => t.name));
+
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: this.isInternalMode() ? [...externalTools, ...internalTools] : externalTools,
     }));
 
-    // Handle tool calls
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      const { name, arguments: args } = request.params;
+      const { name, arguments: args = {} } = request.params;
 
       try {
+        if (internalToolNames.has(name)) {
+          this.requireInternalMode(name);
+        }
         switch (name) {
+          case 'get_setup':
+            return await this.getSetup(args);
           case 'list_components':
             return await this.listComponents(args.type || 'all');
           case 'get_component_info':


### PR DESCRIPTION
**Prvý tool z Fázy 2** MCP redesignu (viď `docs/guides/mcp-audit.md`). Pridáva `get_setup`, ktorý externým projektom (Lovable, Cursor, Claude Code) vráti **hotové `<link>`/`<script>` tagy** s aktuálnymi hashami z hostovaného `rev-manifest.json` — napojenie Martinus stylingu bez checkoutu repa. URL formát `path?v=<hash>` zaisťuje, že **embeds prežijú ďalší styleguide release** (stará hashed-filename varianta by pri každom rebuild-e zlomila existujúce stránky). Zároveň založený **two-mode skeleton** (`MARTINUS_STYLEGUIDE_APP_DIR` env var) — internal mode pre Docker/contribútorov, external mode pre budúcu npx distribúciu.

## Detaily

- Nový tool **`get_setup`** — parameter `language: "sk" | "cz"` (default `sk`); response: `{htmlClasses, head, bodyEnd, language, assetsBaseUrl, bundleVersions}`. Font Awesome Pro vždy included (rozhodnutie v audit §6).
- **Fetch client** s 5-min TTL cache pre `rev-manifest.json`. `ASSETS_BASE_URL` konfigurovateľný cez `MARTINUS_STYLEGUIDE_ASSETS_URL` env var.
- **Two-mode split.** `MARTINUS_STYLEGUIDE_APP_DIR` unset = external mode (v `tools/list` len `get_setup`, filesystem tools hidden, prípadné volanie vráti clean error). Set = internal mode (+ pôvodných 8 tools).
- **Cache-busting cez query-string** (`styles/main.css?v=<hash>`) namiesto hashed filename. Overené, že hosting servíruje aj unversioned aj hashed cesty súbežne.
- **Docker compose:** pridaný `MARTINUS_STYLEGUIDE_APP_DIR=/app/app` pre `mcp-server` službu — interní devs v Dockeri dostanú internal mode automaticky.
- **Audit `docs/guides/mcp-audit.md`** aktualizovaný: §2 cache-busting rationale, §6 nové rozhodnutia (URL formát, FA policy), §7 progress tracking (`get_setup` ✅).

## Test plan

- [ ] `./mcp.sh` rebuild kontajnera, `/mcp` reconnect v Claude Code
- [ ] `get_setup` vráti URLs s `?v=<hash>` (nie `.<hash>.` v mene súboru)
- [ ] `get_setup({language: "cz"})` zmení inline `selectLanguage` v `bodyEnd`
- [ ] Pôvodné internal tools (`list_components`, `list_pug_mixins`, …) v Dockeri stále fungujú
- [ ] Bez env vara (simulácia npx scenára: `node mcp-server/src/index.js`) server štartuje a `tools/list` vráti iba `get_setup`
- [ ] Vloženie `head`/`bodyEnd` snippet do prázdneho HTML súboru → stránka načíta Tabac Sans, main.css, vendor.js, main.js, font-awesome.js bez chýb v konzole