### PR TITLE
MCP: get_component + parametrická šablóna (buttons)

### DIFF
--- a/app/mcp-components.yaml
+++ b/app/mcp-components.yaml
@@ -1,0 +1,66 @@
+#
+# Component schema for the MCP `get_component` tool.
+#
+# Each entry under `components` declares:
+#   - `description`   — one-line prose shown to the AI agent.
+#   - `template`      — HTML string with Mustache-style interpolation:
+#                         {{var}}           HTML-escaped value
+#                         {{{var}}}         raw value (slot content)
+#                         {{#var}}…{{/var}} render block only if var is truthy
+#                         {{^var}}…{{/var}} render block only if var is falsy
+#   - `params`        — named parameters accepted by the component.
+#                         - type: string | enum | boolean
+#                         - required: true | false (default false)
+#                         - values: […]      (required for enum)
+#                         - default: …       (optional)
+#                         - description: prose shown to the agent
+#   - `requires`      — base asset bundles the rendered HTML depends on.
+#   - `addRequiresWhen` — param-name → extra bundles, appended when that
+#                         param is truthy at render time.
+#
+# Kept as one file for now. When this grows, split per-component later.
+#
+
+components:
+
+  buttons:
+    description: >-
+      Standard Martinus button. Pick a visual variant, optional size/shape,
+      optional Font Awesome icon rendered before the label. Renders a
+      <button> element; wrap or swap the tag on the consumer side if you
+      need an <a>.
+    template: |-
+      <button class="btn{{#variant}} btn--{{variant}}{{/variant}}{{#size}} btn--{{size}}{{/size}}{{#shape}} btn--{{shape}}{{/shape}}"{{#disabled}} disabled{{/disabled}}>{{#icon}}<i class="far fa-{{icon}}"></i> {{/icon}}{{label}}</button>
+    params:
+      label:
+        type: string
+        required: true
+        description: Visible button text.
+      variant:
+        type: enum
+        values: [primary, secondary, ghost, ghost-inverse, success]
+        description: >-
+          Visual style. Omit for the default filled button (no modifier class).
+      size:
+        type: enum
+        values: [small, large]
+        description: Optional size modifier. Omit for the default size.
+      shape:
+        type: enum
+        values: [sharp, round, equal]
+        description: >-
+          Optional shape modifier. `sharp` removes border-radius, `round`
+          makes it a pill, `equal` forces equal width and height (useful
+          with an icon and empty label).
+      icon:
+        type: string
+        description: >-
+          Optional Font Awesome Pro icon name without the `fa-` prefix
+          (regular style). When set, font-awesome is added to `requires`.
+      disabled:
+        type: boolean
+        default: false
+        description: Add the `disabled` attribute.
+    requires: []
+    addRequiresWhen:
+      icon: [font-awesome]

--- a/mcp-server/src/index.js
+++ b/mcp-server/src/index.js
@@ -21,7 +21,86 @@ const APP_DIR = process.env.MARTINUS_STYLEGUIDE_APP_DIR || null;
 const ASSETS_BASE_URL = (process.env.MARTINUS_STYLEGUIDE_ASSETS_URL
   || 'https://mrtns.sk/assets/martinus/lb/').replace(/\/?$/, '/');
 const MANIFEST_URL = `${ASSETS_BASE_URL}rev-manifest.json`;
+const COMPONENTS_URL = `${ASSETS_BASE_URL}mcp-components.json`;
 const MANIFEST_CACHE_TTL_MS = 5 * 60 * 1000;
+const COMPONENTS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function isTruthy(value) {
+  return value !== undefined && value !== null && value !== false && value !== '';
+}
+
+/**
+ * Tiny Mustache-subset template engine used to render component HTML.
+ * Supports: {{var}} (escaped), {{{var}}} (raw), {{#var}}…{{/var}} (if truthy),
+ * {{^var}}…{{/var}} (if falsy). No nested blocks with the same key.
+ */
+function renderTemplate(tpl, data) {
+  let out = tpl;
+
+  const blockRe = /\{\{([#^])(\w+)\}\}([\s\S]*?)\{\{\/\2\}\}/g;
+  let prev;
+  do {
+    prev = out;
+    out = out.replace(blockRe, (_, op, key, body) => {
+      const truthy = isTruthy(data[key]);
+      const keep = op === '#' ? truthy : !truthy;
+      return keep ? body : '';
+    });
+  } while (out !== prev);
+
+  out = out.replace(/\{\{\{(\w+)\}\}\}/g, (_, key) => {
+    const v = data[key];
+    return v == null ? '' : String(v);
+  });
+  out = out.replace(/\{\{(\w+)\}\}/g, (_, key) => {
+    const v = data[key];
+    return v == null ? '' : escapeHtml(v);
+  });
+
+  return out;
+}
+
+function validateParams(component, name, args) {
+  const schema = component.params || {};
+  const normalized = {};
+  const unknownKeys = Object.keys(args).filter((k) => !Object.prototype.hasOwnProperty.call(schema, k));
+  if (unknownKeys.length) {
+    throw new Error(`Unknown parameter(s) for component "${name}": ${unknownKeys.join(', ')}. Allowed: ${Object.keys(schema).join(', ') || '(none)'}`);
+  }
+  for (const [key, spec] of Object.entries(schema)) {
+    const provided = Object.prototype.hasOwnProperty.call(args, key);
+    let value = provided ? args[key] : spec.default;
+
+    if (!provided && spec.required) {
+      throw new Error(`Missing required parameter "${key}" for component "${name}".`);
+    }
+    if (value === undefined || value === null) {
+      normalized[key] = spec.type === 'boolean' ? false : '';
+      continue;
+    }
+    if (spec.type === 'enum') {
+      if (!Array.isArray(spec.values) || !spec.values.includes(value)) {
+        throw new Error(`Invalid value "${value}" for "${key}". Allowed: ${(spec.values || []).join(', ')}.`);
+      }
+    }
+    if (spec.type === 'boolean') {
+      value = value === true || value === 'true';
+    }
+    if (spec.type === 'string' && typeof value !== 'string') {
+      value = String(value);
+    }
+    normalized[key] = value;
+  }
+  return normalized;
+}
 
 /**
  * MCP Server for Martinus Styleguide
@@ -45,6 +124,7 @@ class StyleguideServer {
     this.scssIndex = null;
     this.pugMixinIndex = null;
     this.manifestCache = null;
+    this.componentsCache = null;
 
     this.setupHandlers();
     this.setupErrorHandling();
@@ -142,6 +222,83 @@ class StyleguideServer {
     };
   }
 
+  async fetchComponents() {
+    const now = Date.now();
+    if (this.componentsCache && (now - this.componentsCache.fetchedAt) < COMPONENTS_CACHE_TTL_MS) {
+      return this.componentsCache.data;
+    }
+
+    // Internal mode prefers the checked-in YAML source — no network hop, no
+    // waiting for a deploy to see local schema edits.
+    let data;
+    if (this.isInternalMode()) {
+      const schemaPath = join(APP_DIR, 'mcp-components.yaml');
+      try {
+        const text = await readFile(schemaPath, 'utf-8');
+        data = yaml.load(text);
+      } catch (err) {
+        throw new Error(`Failed to read component schema from ${schemaPath}: ${err.message}`);
+      }
+    } else {
+      const res = await fetch(COMPONENTS_URL);
+      if (!res.ok) {
+        throw new Error(`Failed to fetch mcp-components.json (${res.status} ${res.statusText}) from ${COMPONENTS_URL}`);
+      }
+      data = await res.json();
+    }
+
+    if (!data || typeof data !== 'object' || !data.components) {
+      throw new Error('Component schema is empty or malformed: expected a top-level `components` map.');
+    }
+    this.componentsCache = { data, fetchedAt: now };
+    return data;
+  }
+
+  async getComponent(args) {
+    const { name, ...params } = args;
+    if (!name || typeof name !== 'string') {
+      throw new Error('Missing required argument "name".');
+    }
+
+    const schema = await this.fetchComponents();
+    const component = schema.components[name];
+    if (!component) {
+      const available = Object.keys(schema.components).sort().join(', ');
+      throw new Error(`Unknown component "${name}". Available: ${available}.`);
+    }
+    if (!component.template || typeof component.template !== 'string') {
+      throw new Error(`Component "${name}" has no template defined.`);
+    }
+
+    const data = validateParams(component, name, params);
+    const html = renderTemplate(component.template, data);
+
+    const requires = Array.isArray(component.requires) ? [...component.requires] : [];
+    if (component.addRequiresWhen) {
+      for (const [paramName, extras] of Object.entries(component.addRequiresWhen)) {
+        if (isTruthy(data[paramName]) && Array.isArray(extras)) {
+          for (const dep of extras) {
+            if (!requires.includes(dep)) requires.push(dep);
+          }
+        }
+      }
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            name,
+            html,
+            params: data,
+            requires,
+          }, null, 2),
+        },
+      ],
+    };
+  }
+
   setupErrorHandling() {
     this.server.onerror = (error) => {
       console.error('[MCP Error]', error);
@@ -167,6 +324,21 @@ class StyleguideServer {
               description: 'UI language for i18n-aware interactive modules (Select, Autocomplete). Default: "sk".',
             },
           },
+        },
+      },
+      {
+        name: 'get_component',
+        description: 'Returns a rendered HTML fragment for a Martinus design-system component. Pass component `name` plus content/variant parameters (e.g. `label`, `variant`, `size`, `icon`). Response contains the final `html`, the normalized `params` used, and a `requires` array of extra asset bundles the HTML depends on (e.g. ["font-awesome"]) — pass those to get_setup if needed. Discover available components, their parameters, and allowed enum values from the published component schema (mcp-components.json) or by calling this tool without args to surface an error listing valid names.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Component name, e.g. "buttons".',
+            },
+          },
+          required: ['name'],
+          additionalProperties: true,
         },
       },
     ];
@@ -289,6 +461,8 @@ class StyleguideServer {
         switch (name) {
           case 'get_setup':
             return await this.getSetup(args);
+          case 'get_component':
+            return await this.getComponent(args);
           case 'list_components':
             return await this.listComponents(args.type || 'all');
           case 'get_component_info':

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "glob": "^11.1.0",
     "gulp": "~4.0.2",
     "gulp-hub": "~4.2.0",
+    "js-yaml": "^4.1.0",
     "lint-staged": "~15.3.0",
     "lodash": "^4.18.1",
     "postcss-scss": "^4.0.9",
@@ -33,6 +34,8 @@
   "scripts": {
     "prepare": "gulp prepare --openssl-legacy-provider",
     "build": "gulp build --openssl-legacy-provider --mode=production",
+    "postbuild": "node scripts/emit-mcp-artifacts.js",
+    "emit-mcp": "node scripts/emit-mcp-artifacts.js",
     "serve": "gulp serve --openssl-legacy-provider",
     "images": "gulp images --openssl-legacy-provider",
     "clear-cache": "gulp clearCache --openssl-legacy-provider",

--- a/scripts/emit-mcp-artifacts.js
+++ b/scripts/emit-mcp-artifacts.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/*
+ * Emits build-time artifacts consumed by the MCP server.
+ *
+ * Runs as a standalone Node script — no Gulp — invoked from the
+ * `postbuild` npm script so it ships with every production build.
+ *
+ * Current outputs:
+ *   dist/mcp-components.json  — parametric component schema, translated
+ *                               from app/mcp-components.yaml.
+ *
+ * Future artifacts (icons.json, tokens.json, class-index.json,
+ * mcp-manifest.json) will be added here as separate steps.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = path.resolve(__dirname, '..');
+const DIST = path.join(ROOT, 'dist');
+
+function emitComponents() {
+  const src = path.join(ROOT, 'app', 'mcp-components.yaml');
+  const out = path.join(DIST, 'mcp-components.json');
+
+  if (!fs.existsSync(src)) {
+    throw new Error(`Missing component schema: ${src}`);
+  }
+  const parsed = yaml.load(fs.readFileSync(src, 'utf8'));
+
+  fs.mkdirSync(DIST, { recursive: true });
+  fs.writeFileSync(out, `${JSON.stringify(parsed, null, 2)}\n`);
+
+  const count = parsed && parsed.components ? Object.keys(parsed.components).length : 0;
+  console.log(`mcp-emit: wrote ${path.relative(ROOT, out)} (${count} components)`);
+}
+
+function main() {
+  emitComponents();
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`mcp-emit failed: ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
**Nový MCP tool `get_component`** s **parametrickou architektúrou** — namiesto pre-renderovaných HTML súborov per variant má každý komponent jeden template string s Mustache-style placeholdermi a deklaratívnu param schému. Agent posiela reálne dáta (`label: "Kúpiť"`, `variant: "outline"`, `icon: "heart"`), MCP validuje + interpoluje + vracia hotový HTML. Výstup: menej tokenov pre LLM, flexibilné kombinácie modifikátorov, žiadna explózia zdrojových súborov.

## Pivot oproti pôvodnému návrhu

Audit §2 pôvodne hovoril o pre-renderovaných `dist/components/<name>.html` fragmentoch. V diskusii sa ukázalo, že to prinesie zbytočný overhead (17 kategórií × priemer 3 varianty = 50+ HTML súborov, každá ďalšia modifikátor-kombinácia = nový súbor, agent musí stringmi manipulovať placeholder \"Button\" → reálny label). Parametrický model rieši všetko naraz. PR audit dokumentáciu neaktualizuje — to príde v samostatnom PR po zmergovaní #633, aby sa vyhlo merge konfliktom.

## Detaily

- **Nový `app/mcp-components.yaml`** — jediný zdroj pravdy pre všetky komponenty. Prvý entry `buttons` (params: `label`, `variant`, `size`, `shape`, `icon`, `disabled`). Formát zdokumentovaný v hlavičke súboru.
- **Tiny template engine** v `mcp-server/src/index.js` (~30 riadkov, bez externej dependency): `{{var}}` s HTML escape, `{{{var}}}` raw (pre slot content), `{{#var}}...{{/var}}` if truthy, `{{^var}}...{{/var}}` if falsy.
- **Validácia parametrov**: required check, enum whitelist, boolean coercion, detekcia neznámych parametrov (error s výpisom dovolených).
- **Dynamické `requires`**: deklaratívny `addRequiresWhen` v schéme — napr. `buttons` pridá `font-awesome` do response-u iba ak je nastavený `icon` param.
- **Two-mode fetch**:
  - Internal mode (`MARTINUS_STYLEGUIDE_APP_DIR` set) — číta YAML priamo z FS, vidí lokálne edity bez rebuild.
  - External mode — fetchuje `dist/mcp-components.json` z hosted URL, 5-min TTL cache (rovnaký pattern ako `rev-manifest.json`).
- **Build integration** bez Gulpu: `scripts/emit-mcp-artifacts.js` (plain Node, volaný z `postbuild` npm scriptu) transformuje `app/mcp-components.yaml` → `dist/mcp-components.json`. Pripravené na ďalšie artefakty (icons, tokens, class-index, manifest).
- **`js-yaml`** pridaný ako explicit devDependency (predtým transitive) — nepridá nič do `yarn.lock`, len spevňuje contract.

## Overené

End-to-end cez JSON-RPC: default render, plná konfigurácia s ikonou (requires array obsahuje `font-awesome`), disabled state, HTML-escape user stringu s `<script>`, invalid enum hodnota, missing required param, neznámy komponent, neznámy parameter — všetko vráti buď rendered HTML alebo MCP error s kontextovou správou.

## Príklad

```
get_component({ name: "buttons", label: "Pridať do košíka", variant: "primary", size: "large", icon: "cart-shopping" })
→ {
  "name": "buttons",
  "html": "<button class=\"btn btn--primary btn--large\"><i class=\"far fa-cart-shopping\"></i> Pridať do košíka</button>",
  "params": { label, variant, size, shape: "", icon, disabled: false },
  "requires": ["font-awesome"]
}
```

## Ďalej

Rozšírenie na ostatné kategórie (forms, cards, alerts, modals, tabs, …) — každá pridá entry do `mcp-components.yaml`. Pre komplexnejšie komponenty (modal, card so slotmi) sa osvedčí `{{{body}}}` raw placeholder pre slot content. `header.minimal` a `product-card`/`cover` si vyžiadajú dodatočnú diskusiu o návrhu.