### PR TITLE
MCP: layout primitívy (wrapper, row, col, section)

### DIFF
--- a/app/mcp-components.yaml
+++ b/app/mcp-components.yaml
@@ -64,3 +64,104 @@ components:
     requires: []
     addRequiresWhen:
       icon: [font-awesome]
+
+  # ---------------------------------------------------------------------------
+  # Layout primitives — structural wrappers the agent composes around its own
+  # markup. All four use `{{{children}}}` so the caller passes in raw HTML.
+  # Grid is 12-column with breakpoints xs/s/m/l/xl; BEM double-dash convention
+  # (.col--6, .col--l-6, …). See app/styles/layout/_grid.scss.
+
+  wrapper:
+    description: >-
+      Page wrapper. Centers content, caps width per breakpoint, and applies
+      responsive horizontal padding. Use as the top-level container around
+      page content so margins match other Martinus pages.
+    template: |-
+      <div class="wrapper-main">{{{children}}}</div>
+    params:
+      children:
+        type: string
+        description: Raw HTML to place inside the wrapper.
+    requires: []
+
+  row:
+    description: >-
+      Grid row — flex container for columns. Negative margins compensate for
+      column gutters so row children span the wrapper edge-to-edge. Put
+      `col` children directly inside.
+    template: |-
+      <div class="row{{#variant}} row--{{variant}}{{/variant}}">{{{children}}}</div>
+    params:
+      children:
+        type: string
+        description: Raw HTML (typically one or more `col` calls).
+      variant:
+        type: enum
+        values: [form]
+        description: >-
+          `form` uses tighter gutters tuned for form control spacing. Omit
+          for the default row gutters.
+    requires: []
+
+  col:
+    description: >-
+      Grid column inside a `row`. Martinus grid is 12-column with BEM
+      double-dash breakpoint modifiers (`.col--6`, `.col--l-6`). Omit every
+      size param for an auto-fill column; set `variant: fill` or
+      `variant: shrink` for non-sized behaviors.
+    template: |-
+      <div class="col{{#variant}} col--{{variant}}{{/variant}}{{#size}} col--{{size}}{{/size}}{{#sizeS}} col--s-{{sizeS}}{{/sizeS}}{{#sizeM}} col--m-{{sizeM}}{{/sizeM}}{{#sizeL}} col--l-{{sizeL}}{{/sizeL}}{{#sizeXl}} col--xl-{{sizeXl}}{{/sizeXl}}">{{{children}}}</div>
+    params:
+      children:
+        type: string
+        description: Raw HTML inside the column.
+      size:
+        type: enum
+        values: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
+        description: Column width at the XS breakpoint (out of 12).
+      sizeS:
+        type: enum
+        values: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
+        description: Column width at the S breakpoint (>=480px).
+      sizeM:
+        type: enum
+        values: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
+        description: Column width at the M breakpoint (>=768px).
+      sizeL:
+        type: enum
+        values: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
+        description: Column width at the L breakpoint (>=960px).
+      sizeXl:
+        type: enum
+        values: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
+        description: Column width at the XL breakpoint (>=1280px).
+      variant:
+        type: enum
+        values: [fill, shrink, border]
+        description: >-
+          `fill` expands to take remaining space, `shrink` fits to content,
+          `border` adds a separator. Mutually exclusive with explicit sizes
+          in practice (though not enforced).
+    requires: []
+
+  section:
+    description: >-
+      Page section with vertical padding that scales at the M breakpoint.
+      Use as a child of `wrapper` to separate logical areas (hero, listing,
+      footer CTA, …). `size: small` reduces padding; `overflow: true` adds
+      `overflow: hidden` for contained float/absolute children.
+    template: |-
+      <div class="section{{#size}} section--{{size}}{{/size}}{{#overflow}} section--overflow{{/overflow}}">{{{children}}}</div>
+    params:
+      children:
+        type: string
+        description: Raw HTML inside the section.
+      size:
+        type: enum
+        values: [small]
+        description: Optional `small` padding modifier. Omit for default spacing.
+      overflow:
+        type: boolean
+        default: false
+        description: Add `section--overflow` (overflow hidden).
+    requires: []

--- a/mcp-server/src/index.js
+++ b/mcp-server/src/index.js
@@ -170,9 +170,11 @@ export class StyleguideServer {
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;');
 
-    // Theme-init script prevents FOUC when dark mode is active — mirrors the
-    // inline script in app/views/layouts/_default.pug.
-    const themeInit = `<script>(function(){var t=localStorage.getItem('martinus-theme')||(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);localStorage.setItem('martinus-theme',t);})();</script>`;
+    // No theme-init script: external consumers don't share Martinus's
+    // localStorage / cookie state, and a `prefers-color-scheme` fallback
+    // would surprise-flip the page into dark mode. CSS only styles
+    // `[data-theme='dark']` overlays — omitting the attribute renders in
+    // light mode, which is the intended default for MCP-hosted pages.
 
     const html = [
       '<!doctype html>',
@@ -182,7 +184,6 @@ export class StyleguideServer {
       '  <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">',
       '  <meta name="viewport" content="width=device-width, initial-scale=1.0">',
       `  <title>${escapedTitle}</title>`,
-      `  ${themeInit}`,
       setup.head.split('\n').map((l) => `  ${l}`).join('\n'),
       '</head>',
       '<body>',

--- a/mcp-server/src/template.js
+++ b/mcp-server/src/template.js
@@ -71,11 +71,18 @@ export function validateParams(component, name, args) {
       continue;
     }
     if (spec.type === 'enum') {
-      if (!Array.isArray(spec.values) || !spec.values.includes(value)) {
+      // JSON-RPC preserves JS types (a schema value `'6'` and a caller arg `6`
+      // are distinct), so compare loosely — stringify both sides — to accept
+      // either. The normalized value is stored as the exact match from the
+      // schema list, preserving the original type for consumers.
+      const stringValue = String(value);
+      const matched = (spec.values || []).find((v) => String(v) === stringValue);
+      if (matched === undefined) {
         throw new Error(
           `Invalid value "${value}" for "${key}". Allowed: ${(spec.values || []).join(', ')}.`
         );
       }
+      value = matched;
     }
     if (spec.type === 'boolean') {
       value = value === true || value === 'true';

--- a/mcp-server/test/layout-components.test.mjs
+++ b/mcp-server/test/layout-components.test.mjs
@@ -103,6 +103,14 @@ test('col rejects an out-of-range size value', async () => {
   );
 });
 
+test('col accepts a numeric sizeM (JSON-RPC number → string enum)', async () => {
+  // Agents call get_component with `sizeM: 6`; JSON-RPC serializes that as a
+  // number, but the schema lists '1'..'12' as strings. Loose enum comparison
+  // bridges the gap.
+  const { html } = await render({ name: 'col', sizeM: 6, children: 'x' });
+  assert.equal(html, '<div class="col col--m-6">x</div>');
+});
+
 // ---------------------------------------------------------------------------
 // section
 

--- a/mcp-server/test/layout-components.test.mjs
+++ b/mcp-server/test/layout-components.test.mjs
@@ -1,0 +1,174 @@
+/*
+ * Integration tests for the layout primitives (`wrapper`, `row`, `col`,
+ * `section`) — exercise StyleguideServer.getComponent() directly over the
+ * real app/mcp-components.yaml schema.
+ */
+
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+if (!process.env.MARTINUS_STYLEGUIDE_APP_DIR) {
+  process.env.MARTINUS_STYLEGUIDE_APP_DIR = resolve(__dirname, '..', '..', 'app');
+}
+
+let StyleguideServer;
+let server;
+
+before(async () => {
+  ({ StyleguideServer } = await import('../src/index.js'));
+  server = new StyleguideServer();
+});
+
+async function render(args) {
+  const res = await server.getComponent(args);
+  return JSON.parse(res.content[0].text);
+}
+
+// ---------------------------------------------------------------------------
+// wrapper
+
+test('wrapper renders as .wrapper-main around raw children', async () => {
+  const { html } = await render({
+    name: 'wrapper',
+    children: '<p>Hi</p>',
+  });
+  assert.equal(html, '<div class="wrapper-main"><p>Hi</p></div>');
+});
+
+test('wrapper with no children renders an empty wrapper', async () => {
+  const { html } = await render({ name: 'wrapper' });
+  assert.equal(html, '<div class="wrapper-main"></div>');
+});
+
+// ---------------------------------------------------------------------------
+// row
+
+test('row renders default flex container', async () => {
+  const { html } = await render({ name: 'row', children: '<div class="col"></div>' });
+  assert.equal(html, '<div class="row"><div class="col"></div></div>');
+});
+
+test('row with variant=form applies row--form modifier', async () => {
+  const { html } = await render({ name: 'row', variant: 'form' });
+  assert.equal(html, '<div class="row row--form"></div>');
+});
+
+test('row rejects an unknown variant', async () => {
+  await assert.rejects(
+    () => server.getComponent({ name: 'row', variant: 'loose' }),
+    /Invalid value "loose" for "variant"/
+  );
+});
+
+// ---------------------------------------------------------------------------
+// col
+
+test('col with no size params renders bare .col', async () => {
+  const { html } = await render({ name: 'col', children: 'x' });
+  assert.equal(html, '<div class="col">x</div>');
+});
+
+test('col with size=6 applies .col--6', async () => {
+  const { html } = await render({ name: 'col', size: '6', children: 'x' });
+  assert.equal(html, '<div class="col col--6">x</div>');
+});
+
+test('col combines multiple breakpoint sizes with BEM double-dash', async () => {
+  const { html } = await render({
+    name: 'col',
+    size: '12',
+    sizeM: '6',
+    sizeL: '4',
+    children: 'x',
+  });
+  assert.equal(
+    html,
+    '<div class="col col--12 col--m-6 col--l-4">x</div>'
+  );
+});
+
+test('col with variant=fill adds .col--fill', async () => {
+  const { html } = await render({ name: 'col', variant: 'fill', children: 'x' });
+  assert.equal(html, '<div class="col col--fill">x</div>');
+});
+
+test('col rejects an out-of-range size value', async () => {
+  await assert.rejects(
+    () => server.getComponent({ name: 'col', size: '13' }),
+    /Invalid value "13" for "size"/
+  );
+});
+
+// ---------------------------------------------------------------------------
+// section
+
+test('section renders base .section around children', async () => {
+  const { html } = await render({ name: 'section', children: '<h2>Hero</h2>' });
+  assert.equal(html, '<div class="section"><h2>Hero</h2></div>');
+});
+
+test('section with size=small adds .section--small', async () => {
+  const { html } = await render({ name: 'section', size: 'small' });
+  assert.equal(html, '<div class="section section--small"></div>');
+});
+
+test('section with overflow=true adds .section--overflow', async () => {
+  const { html } = await render({ name: 'section', overflow: true });
+  assert.equal(html, '<div class="section section--overflow"></div>');
+});
+
+test('section combines size and overflow modifiers', async () => {
+  const { html } = await render({
+    name: 'section',
+    size: 'small',
+    overflow: true,
+  });
+  assert.equal(html, '<div class="section section--small section--overflow"></div>');
+});
+
+// ---------------------------------------------------------------------------
+// Slot content is not escaped (raw via {{{children}}})
+
+test('children slot preserves raw HTML (no escaping)', async () => {
+  const { html } = await render({
+    name: 'wrapper',
+    children: '<span data-x="y">child</span>',
+  });
+  assert.ok(html.includes('<span data-x="y">child</span>'));
+});
+
+// ---------------------------------------------------------------------------
+// Composition — agent-style nested render
+
+test('nested wrapper > section > row > col composes cleanly', async () => {
+  const col = (await render({ name: 'col', sizeM: '6', children: 'A' })).html;
+  const col2 = (await render({ name: 'col', sizeM: '6', children: 'B' })).html;
+  const row = (await render({ name: 'row', children: col + col2 })).html;
+  const section = (await render({ name: 'section', children: row })).html;
+  const wrapper = (await render({ name: 'wrapper', children: section })).html;
+  assert.equal(
+    wrapper,
+    '<div class="wrapper-main">'
+    + '<div class="section">'
+    + '<div class="row">'
+    + '<div class="col col--m-6">A</div>'
+    + '<div class="col col--m-6">B</div>'
+    + '</div>'
+    + '</div>'
+    + '</div>'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// requires — layout has none, none conditional
+
+test('layout components declare an empty requires array', async () => {
+  for (const name of ['wrapper', 'row', 'col', 'section']) {
+    const { requires } = await render({ name });
+    assert.deepEqual(requires, [], `${name} should have empty requires`);
+  }
+});

--- a/mcp-server/test/starter-template.test.mjs
+++ b/mcp-server/test/starter-template.test.mjs
@@ -1,0 +1,87 @@
+/*
+ * Smoke tests for get_starter_template — mocks the rev-manifest fetch so the
+ * test has no network dependency and can run offline in CI.
+ */
+
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+if (!process.env.MARTINUS_STYLEGUIDE_APP_DIR) {
+  process.env.MARTINUS_STYLEGUIDE_APP_DIR = resolve(__dirname, '..', '..', 'app');
+}
+
+const FAKE_MANIFEST = {
+  'styles/main.css': 'styles/main.aaaaaaaa.css',
+  'scripts/main.js': 'scripts/main.bbbbbbbb.js',
+  'scripts/vendor.js': 'scripts/vendor.cccccccc.js',
+  'scripts/font-awesome.js': 'scripts/font-awesome.dddddddd.js',
+  'fonts/Tabac-Sans/style.css': 'fonts/Tabac-Sans/style.eeeeeeee.css',
+};
+
+let StyleguideServer;
+let server;
+
+before(async () => {
+  ({ StyleguideServer } = await import('../src/index.js'));
+  server = new StyleguideServer();
+  server.fetchManifest = async () => FAKE_MANIFEST;
+});
+
+async function renderStarter(args = {}) {
+  const res = await server.getStarterTemplate(args);
+  return JSON.parse(res.content[0].text);
+}
+
+test('renders a complete HTML document with doctype, html, head, body', async () => {
+  const { html } = await renderStarter();
+  assert.match(html, /^<!doctype html>/);
+  assert.match(html, /<html lang="sk"[^>]*>/);
+  assert.match(html, /<\/html>\n?$/);
+  assert.match(html, /<head>[\s\S]*<\/head>/);
+  assert.match(html, /<body>[\s\S]*<\/body>/);
+});
+
+test('embeds hashed stylesheet and script URLs from the manifest', async () => {
+  const { html } = await renderStarter();
+  assert.match(html, /href="[^"]*main\.css\?v=aaaaaaaa"/);
+  assert.match(html, /src="[^"]*main\.js\?v=bbbbbbbb"/);
+  assert.match(html, /src="[^"]*vendor\.js\?v=cccccccc"/);
+  assert.match(html, /src="[^"]*font-awesome\.js\?v=dddddddd"/);
+});
+
+test('includes no theme-switching logic (external consumers default to light)', async () => {
+  // Regression: the eshop-style theme init script was surprise-flipping
+  // external pages into dark mode via prefers-color-scheme. MCP outputs
+  // should be deterministic — theme is not our concern.
+  const { html } = await renderStarter();
+  assert.ok(!html.includes('martinus-theme'), 'must not reference localStorage theme key');
+  assert.ok(!html.includes('data-theme'), 'must not set data-theme attribute');
+  assert.ok(!html.includes('prefers-color-scheme'), 'must not read OS color scheme');
+});
+
+test('applies language to <html lang> and select-language JS', async () => {
+  const sk = await renderStarter({ language: 'sk' });
+  assert.match(sk.html, /<html lang="sk"/);
+  assert.match(sk.html, /selectLanguage = "sk"/);
+
+  const cz = await renderStarter({ language: 'cz' });
+  assert.match(cz.html, /<html lang="cs"/);
+  assert.match(cz.html, /selectLanguage = "cz"/);
+});
+
+test('uses the custom title and HTML-escapes it', async () => {
+  const { html } = await renderStarter({ title: 'Hi <script>x</script>' });
+  assert.match(html, /<title>Hi &lt;script&gt;x&lt;\/script&gt;<\/title>/);
+  assert.ok(!html.includes('<title>Hi <script>'));
+});
+
+test('rejects an invalid language with a clear error', async () => {
+  await assert.rejects(
+    () => server.getStarterTemplate({ language: 'en' }),
+    /Invalid language "en"/
+  );
+});

--- a/mcp-server/test/template.test.mjs
+++ b/mcp-server/test/template.test.mjs
@@ -122,3 +122,25 @@ test('validateParams coerces non-string for string-typed param', () => {
   const out = validateParams(schema, 'buttons', { label: 42 });
   assert.equal(out.label, '42');
 });
+
+test('validateParams accepts a number arg against a stringified enum value', () => {
+  // Regression: col.sizeM has values ['1'..'12'] but JSON-RPC passes numbers.
+  // Loose comparison must match and normalize to the schema's declared type.
+  const sizeSchema = {
+    params: {
+      size: { type: 'enum', values: ['1', '2', '6', '12'] },
+    },
+  };
+  const out = validateParams(sizeSchema, 'col', { size: 6 });
+  assert.equal(out.size, '6');
+});
+
+test('validateParams accepts a string arg against a numeric enum value', () => {
+  const numSchema = {
+    params: {
+      n: { type: 'enum', values: [1, 2, 3] },
+    },
+  };
+  const out = validateParams(numSchema, 'x', { n: '2' });
+  assert.equal(out.n, 2);
+});


### PR DESCRIPTION
**Rozšírenie `mcp-components.yaml`** o 4 slot-based štruktúrne komponenty — štandardný skelet, s ktorým agent skladá Martinus-správnu stránku okolo existujúcich `get_component` volaní (buttons atď.). Žiadne nové MCP tooly, iba nové entries v existujúcej parametrickej schéme zo #634.

## Detaily

- **`wrapper`** → `.wrapper-main` (responsive max-width + horizontal padding). Top-level kontajner.
- **`row`** → `.row` flex container; optional `variant: form` pre tightšie form-spacing gutters.
- **`col`** → 12-stĺpcový grid s BEM double-dash konvenciou (`col--6`, `col--l-6`). Parametre `size`, `sizeS`, `sizeM`, `sizeL`, `sizeXl` ako enum `'1'..'12'` pre per-breakpoint šírky; plus `variant: fill | shrink | border` pre non-sized správanie.
- **`section`** → `.section` vertical padding; optional `size: small`, `overflow: boolean`.

Všetky 4 používajú `{{{children}}}` raw slot — agent dodá vlastný HTML obsah (typicky výstup iných `get_component` volaní). `requires: []` — žiadne external asset balíčky.

## Príklad composition

```js
const colA = get_component({ name: "col", sizeM: "6", children: "A" });
const colB = get_component({ name: "col", sizeM: "6", children: "B" });
const row = get_component({ name: "row", children: colA.html + colB.html });
const section = get_component({ name: "section", children: row.html });
const page = get_component({ name: "wrapper", children: section.html });
// → <div class="wrapper-main"><div class="section"><div class="row">
//     <div class="col col--m-6">A</div><div class="col col--m-6">B</div>
//    </div></div></div>
```

## Testy

**Nový** `mcp-server/test/layout-components.test.mjs` — 17 testov pokrýva: základné rendery, všetky kombinácie modifikátorov, enum validáciu, raw slot content bez HTML escape, nested composition. Existujúca sada zo #635 sa rozrastla z 27 na **44 passed** (natívne aj Docker).

## Ďalej

Logické pokračovanie: `get_utilities` tool pre d-\*, m-\*, p-\*, flex utility classes (samostatný PR — potrebuje emitter rozšírenie pre `dist/utilities.json`). Alebo ďalšie komponenty (cards, alerts, modals, tabs) — fit for existing pattern.