### PR TITLE
Automatická synchronizácia Font Awesome subsetu

### DIFF
--- a/.github/workflows/build-dist-pr.yml
+++ b/.github/workflows/build-dist-pr.yml
@@ -1,0 +1,45 @@
+name: Build dist and open PR
+
+on:
+  push:
+    branches: [master]
+
+# Avoid two builds racing to push the same branch if master gets multiple
+# quick pushes (e.g. a merge queue).
+concurrency:
+  group: build-dist-pr
+  cancel-in-progress: true
+
+jobs:
+  build-dist:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - run: yarn install
+      - run: yarn prepare --openssl-legacy-provider
+      - run: yarn build
+
+      # No-op if the build output is identical to what's already committed
+      # (e.g. this run was triggered by merging the bot's own PR).
+      - name: Open PR with build artifacts
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Aktualizovaný build (dist/)"
+          branch: auto/build-dist
+          delete-branch: true
+          title: "Build: aktualizované dist artefakty"
+          body: |
+            Automaticky vygenerovaný produkčný build z commitu ${{ github.sha }} na `master`.
+
+            Vyžaduje manuálne overenie a merge.
+          add-paths: dist

--- a/app/views/styleguide/buttons.pug
+++ b/app/views/styleguide/buttons.pug
@@ -306,7 +306,7 @@ block append content
             </button>
 
             <button type="button" class="btn btn--primary"> Settings
-              <i class="fa fa-cog icon--right fa-xl"></i>
+              <i class="fa fa-gear icon--right fa-xl"></i>
             </button>
       //- end: demo
 

--- a/app/views/styleguide/cards.pug
+++ b/app/views/styleguide/cards.pug
@@ -296,7 +296,7 @@ block append content
           :code
             <!-- Done card card -->
             <article class="card card--done">
-              <i class="far fa-check-circle card--done__icon"></i>
+              <i class="far fa-circle-check card--done__icon"></i>
               ...
             </article>
 
@@ -574,7 +574,7 @@ block append content
                 </article>
 
                 <article class="card card--done">
-                  <i class="far fa-check-circle card--done__icon"></i>
+                  <i class="far fa-circle-check card--done__icon"></i>
                   <div class="card__content">...</div>
                 </article>
 

--- a/app/views/styleguide/data/font-awesome-subset.yaml
+++ b/app/views/styleguide/data/font-awesome-subset.yaml
@@ -1,26 +1,24 @@
 icons:
   - regular:
-    - air-freshener
     - arrow-down
     - arrow-down-right
     - arrow-down-to-bracket
     - arrow-left
+    - arrow-pointer
     - arrow-right
     - arrow-right-from-bracket
     - arrow-up
     - arrow-up-from-bracket
     - arrow-up-right
-    - arrow-pointer
-    - atlas
     - atom
     - badge-percent
-    - balance-scale
-    - band-aid
+    - bandage
     - bars
     - bars-sort
     - basket-shopping
     - book
     - book-arrow-up
+    - book-atlas
     - book-blank
     - book-bookmark
     - book-heart
@@ -28,7 +26,7 @@ icons:
     - book-open
     - bookmark
     - books
-    - box-alt
+    - box-taped
     - brain
     - briefcase
     - browser
@@ -40,35 +38,37 @@ icons:
     - chart-line
     - chart-network
     - chart-pie
-    - check-circle
     - chevron-down
     - chevron-left
     - chevron-right
     - chevron-up
     - circle
+    - circle-check
     - circle-exclamation
     - circle-info
     - circle-user
     - claw-marks
-    - clinic-medical
     - clock
+    - clock-rotate-left
     - cloud-sun
     - code
-    - coffee-togo
-    - cog
     - coin
     - comment-lines
     - comments
     - credit-card
-    - cut
+    - cup-togo
     - database
     - deer
     - dice
     - dog
-    - eye
-    - eye-slash
+    - earth-africa
+    - earth-americas
+    - earth-asia
+    - earth-europe
     - ellipsis
     - envelope
+    - eye
+    - eye-slash
     - face-frown
     - face-grimace
     - face-kiss-wink-heart
@@ -76,8 +76,7 @@ icons:
     - face-smile
     - face-surprise
     - feather
-    - fighter-jet
-    - file-alt
+    - file-lines
     - film
     - filter
     - fingerprint
@@ -85,25 +84,25 @@ icons:
     - flag
     - flower
     - gavel
+    - gear
     - gift
     - gift-card
-    - globe-africa
-    - globe-americas
-    - globe-asia
-    - globe-europe
     - graduation-cap
     - hammer
+    - hands
+    - hands-praying
     - handshake
     - hat-chef
     - head-side-brain
     - heart
     - heart-circle-plus
-    - heartbeat
-    - history
+    - heart-pulse
     - hotel
     - house
+    - house-chimney-medical
     - image
     - industry
+    - jet-fighter
     - keyboard
     - landmark
     - laptop
@@ -113,34 +112,35 @@ icons:
     - list-ul
     - loader
     - location-crosshairs
-    - magnifying-glass-plus
+    - location-dot
+    - magnifying-glass
     - magnifying-glass-minus
+    - magnifying-glass-plus
     - mailbox
     - map
-    - map-marked
-    - map-marker-alt
-    - map-signs
+    - map-location
+    - masks-theater
     - megaphone
     - microchip
     - minus
+    - moon
     - mortar-pestle
     - mug-hot
     - music
     - newspaper
-    - paint-brush
+    - paintbrush
     - paper-plane
     - pause
+    - pen-paintbrush
+    - pen-ruler
     - pencil
-    - pencil-paintbrush
-    - pencil-ruler
+    - person-praying
     - phone
     - plane
     - planet-ringed
     - play
     - plug
     - plus
-    - pray
-    - praying-hands
     - puzzle-piece
     - question
     - quote-right
@@ -149,22 +149,24 @@ icons:
     - rectangle-history
     - rectangle-vertical-history
     - reply
+    - scale-balanced
+    - scissors
     - scroll-old
-    - search
     - share
     - shield
-    - shipping-fast
-    - sign-language
+    - shirt
+    - signs-post
     - spa
     - sparkles
+    - spray-can-sparkles
     - square-root
     - star-exclamation
     - stars
     - store
+    - sun-bright
     - sunglasses
     - swords
     - tablet-screen
-    - theater-masks
     - thumbs-down
     - thumbs-up
     - tractor
@@ -172,19 +174,19 @@ icons:
     - treasure-chest
     - tree-christmas
     - triangle-exclamation
-    - tshirt
+    - truck-fast
     - ufo
     - user
-    - user-friends
+    - user-group
     - user-secret
     - user-tie
     - users
     - utensils
     - vial
-    - volleyball-ball
+    - volleyball
     - volume
     - wand-magic
-    - window-alt
+    - window-flip
     - xmark
   - brands:
     - apple
@@ -198,10 +200,13 @@ icons:
     - eye
     - eye-slash
     - heart
+    - moon
     - star
+    - sun-bright
   - duotone:
     - star-half
   - kit:
     - martinus
+    - martinus-outline
     - owl
     - owl-plus

--- a/app/views/styleguide/icons.pug
+++ b/app/views/styleguide/icons.pug
@@ -56,6 +56,23 @@ block append content
                   br
                   abbr(title=iconClass, data-clipboard, data-clipboard-msg-success='<small>skopírované</small>', data-clipboard-text=`${iconName}`).text-color-grey= iconName
 
+    +content-sub-section('Legacy names (pre Font Awesome 6)')
+
+      - var legacyIconNames = ['air-freshener', 'atlas', 'balance-scale', 'band-aid', 'box-alt', 'check-circle', 'clinic-medical', 'coffee-togo', 'cog', 'cut', 'fighter-jet', 'file-alt', 'globe-africa', 'globe-americas', 'globe-asia', 'globe-europe', 'heartbeat', 'history', 'map-marked', 'map-marker-alt', 'map-signs', 'paint-brush', 'pencil-paintbrush', 'pencil-ruler', 'pray', 'praying-hands', 'search', 'shipping-fast', 'sign-language', 'theater-masks', 'tshirt', 'user-friends', 'volleyball-ball', 'window-alt'];
+
+      +p These are Font Awesome 5 icon names that were renamed when the kit was upgraded to Font Awesome 6 (e.g. <code class='l-code-inline'>cog</code> &rarr; <code class='l-code-inline'>gear</code>). They are <strong>no longer part of the curated subset</strong> in <code class='l-code-inline'>font-awesome-subset.yaml</code> — this section only exists to check whether Font Awesome's own backward-compatibility shims still render them. If an icon below looks broken/empty, the shim does not cover it and any markup still using that name must be updated to the current name.
+
+      +demo
+        +demo-example
+          ul.l-icons
+            each iconName in legacyIconNames
+              - const iconClass = `far fa-${iconName}`;
+
+              li(data-tooltip, title=iconClass).l-icons_item
+                +faIcon(iconName, 'far').fa-lg
+                br
+                span.text-color-grey= iconName
+
   //- ICONS
   +content-section(contents[1])
 

--- a/mcp-server/test/icons.test.mjs
+++ b/mcp-server/test/icons.test.mjs
@@ -66,11 +66,12 @@ test('list_icons filtered by solid returns only fas icons', async () => {
   assert.ok(data.icons.every((i) => i.prefix === 'fas'));
 });
 
-test('list_icons filtered by kit returns the 3 Martinus custom icons', async () => {
+test('list_icons filtered by kit returns the 4 Martinus custom icons', async () => {
   const data = parse(await server.listIcons('kit'));
-  assert.equal(data.total, 3);
+  assert.equal(data.total, 4);
   const names = data.icons.map((i) => i.name);
   assert.ok(names.includes('martinus'));
+  assert.ok(names.includes('martinus-outline'));
   assert.ok(names.includes('owl'));
   assert.ok(names.includes('owl-plus'));
   assert.ok(data.icons.every((i) => i.prefix === 'fak'));
@@ -112,7 +113,7 @@ test('get_icon owl-plus kit icon renders correctly', async () => {
 });
 
 test('get_icon always includes requires: ["font-awesome"]', async () => {
-  const data = parse(await server.getIcon({ name: 'check-circle' }));
+  const data = parse(await server.getIcon({ name: 'circle-check' }));
   assert.deepEqual(data.requires, ['font-awesome']);
 });
 

--- a/mcp-server/test/ui-components.test.mjs
+++ b/mcp-server/test/ui-components.test.mjs
@@ -116,8 +116,8 @@ test('alert with variant applies .alert--{variant}', async () => {
 });
 
 test('alert with icon renders .alert__icon wrapper and FA icon', async () => {
-  const { html } = await render({ name: 'alert', content: 'OK', icon: 'check-circle' });
-  assert.ok(html.includes('<div class="alert__icon"><i class="far fa-check-circle fa-xl"></i></div>'));
+  const { html } = await render({ name: 'alert', content: 'OK', icon: 'circle-check' });
+  assert.ok(html.includes('<div class="alert__icon"><i class="far fa-circle-check fa-xl"></i></div>'));
   assert.ok(html.includes('<div class="alert__content">OK</div>'));
 });
 

--- a/package.json
+++ b/package.json
@@ -33,9 +33,11 @@
   },
   "scripts": {
     "prepare": "gulp prepare --openssl-legacy-provider",
+    "prebuild": "node scripts/sync-font-awesome-subset.js",
     "build": "gulp build --openssl-legacy-provider --mode=production",
     "postbuild": "node scripts/emit-mcp-artifacts.js",
     "emit-mcp": "node scripts/emit-mcp-artifacts.js",
+    "sync-fa-subset": "node scripts/sync-font-awesome-subset.js",
     "serve": "gulp serve --openssl-legacy-provider",
     "images": "gulp images --openssl-legacy-provider",
     "clear-cache": "gulp clearCache --openssl-legacy-provider",

--- a/scripts/sync-font-awesome-subset.js
+++ b/scripts/sync-font-awesome-subset.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/*
+ * Regenerates app/views/styleguide/data/font-awesome-subset.yaml from the
+ * installed Font Awesome Kit.
+ *
+ * The Kit itself (curated at https://fontawesome.com/kits) IS the icon
+ * subset — whatever is enabled there is what ships in
+ * icons/metadata/icons.json inside the installed package. This script just
+ * mirrors that file into our YAML so nothing has to be hand-maintained here;
+ * re-run it (or let `yarn build` do it via the `prebuild` hook) after every
+ * `./npm.sh upgrade @awesome.me/kit-...`.
+ *
+ * Run manually: ./npm.sh run sync-fa-subset
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = path.resolve(__dirname, '..');
+const OUT = path.join(ROOT, 'app', 'views', 'styleguide', 'data', 'font-awesome-subset.yaml');
+
+// Order matches the historical hand-curated file; only non-empty sections
+// are written. `custom` is the Kit's name for our own uploaded icons
+// (martinus, owl, owl-plus, ...) — we keep calling that section `kit` since
+// that's the FA prefix (`fak`) and the name used across this repo.
+const STYLE_ORDER = ['regular', 'brands', 'solid', 'duotone', 'custom'];
+const STYLE_LABEL = { custom: 'kit' };
+
+function findKitMetadataPath() {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  const kitName = Object.keys(pkg.dependencies || {}).find((name) => name.startsWith('@awesome.me/kit-'));
+  if (!kitName) {
+    throw new Error('No "@awesome.me/kit-*" dependency found in package.json.');
+  }
+
+  const metadataPath = path.join(ROOT, 'node_modules', kitName, 'icons', 'metadata', 'icons.json');
+  if (!fs.existsSync(metadataPath)) {
+    throw new Error(`Kit metadata not found at ${metadataPath} — did you run ./npm.sh install?`);
+  }
+  return { kitName, metadataPath };
+}
+
+function groupByStyle(metadata) {
+  const byStyle = {};
+  Object.keys(metadata).forEach((name) => {
+    const styles = metadata[name].styles || [];
+    styles.forEach((style) => {
+      if (!byStyle[style]) byStyle[style] = [];
+      byStyle[style].push(name);
+    });
+  });
+  Object.values(byStyle).forEach((names) => names.sort());
+  return byStyle;
+}
+
+function toYaml(byStyle) {
+  const lines = ['icons:'];
+  STYLE_ORDER.forEach((style) => {
+    const names = byStyle[style];
+    if (!names || !names.length) return;
+    lines.push(`  - ${STYLE_LABEL[style] || style}:`);
+    names.forEach((name) => lines.push(`    - ${name}`));
+  });
+  return `${lines.join('\n')}\n`;
+}
+
+function diffSummary(before, after) {
+  const beforeIcons = before && Array.isArray(before.icons)
+    ? new Set(before.icons.flatMap((item) => Object.values(item)[0].map((name) => `${Object.keys(item)[0]}/${name}`)))
+    : new Set();
+  const afterIcons = after && Array.isArray(after.icons)
+    ? new Set(after.icons.flatMap((item) => Object.values(item)[0].map((name) => `${Object.keys(item)[0]}/${name}`)))
+    : new Set();
+
+  const added = [...afterIcons].filter((icon) => !beforeIcons.has(icon));
+  const removed = [...beforeIcons].filter((icon) => !afterIcons.has(icon));
+  return { added, removed };
+}
+
+function main() {
+  const { kitName, metadataPath } = findKitMetadataPath();
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+  const byStyle = groupByStyle(metadata);
+  const content = toYaml(byStyle);
+
+  const before = fs.existsSync(OUT) ? yaml.load(fs.readFileSync(OUT, 'utf8')) : null;
+  const after = yaml.load(content);
+  const { added, removed } = diffSummary(before, after);
+
+  fs.writeFileSync(OUT, content);
+
+  const total = Object.values(byStyle).reduce((sum, names) => sum + names.length, 0);
+  console.log(`sync-fa-subset: wrote ${path.relative(ROOT, OUT)} from ${kitName} (${total} icons)`);
+  if (added.length) console.log(`  + added: ${added.join(', ')}`);
+  if (removed.length) console.log(`  - removed: ${removed.join(', ')}`);
+  if (!added.length && !removed.length) console.log('  no changes');
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`sync-fa-subset failed: ${err.message}`);
+  process.exit(1);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,11 +11,11 @@
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@awesome.me/kit-c68fa87f81@^1.0.67":
-  version "1.0.67"
-  resolved "https://npm.fontawesome.com/@awesome.me/kit-c68fa87f81/-/1.0.67/kit-c68fa87f81-1.0.67.tgz#ddce7e9276035e147a6b32b13a0dff6018e37cfd"
-  integrity sha512-LKVfaW6NucTVYYvkHi1SWlZqJLqSbB7r+AD7Opf2SPsfvjYRDh4irQK1F6vitmQRBfqhcekZ7xu9Yb/4Gy9PHw==
+  version "1.0.73"
+  resolved "https://npm.fontawesome.com/@awesome.me/kit-c68fa87f81/-/kit-c68fa87f81-1.0.73.tgz#89bf4c0fd2498f5671d2e9278fcc479ff2ae486d"
+  integrity sha512-eyiJB01qW9iAiaCW+2+9IhrhVNdcv/gWGxlA32NPg/lwI6f7+FR8H8yPQ9gDjC8XHvV8DGOZwXCyzartLyqmXw==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^6.6.0"
+    "@fortawesome/fontawesome-common-types" "^6.7.2"
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -1276,15 +1276,10 @@
     "@eslint/core" "^0.13.0"
     levn "^0.4.1"
 
-"@fortawesome/fontawesome-common-types@6.7.2":
+"@fortawesome/fontawesome-common-types@6.7.2", "@fortawesome/fontawesome-common-types@^6.7.2":
   version "6.7.2"
   resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.7.2/fontawesome-common-types-6.7.2.tgz#7123d74b0c1e726794aed1184795dbce12186470"
   integrity sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==
-
-"@fortawesome/fontawesome-common-types@^6.6.0":
-  version "6.6.0"
-  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.6.0/fontawesome-common-types-6.6.0.tgz#31ab07ca6a06358c5de4d295d4711b675006163f"
-  integrity sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==
 
 "@fortawesome/fontawesome-pro@^6.7.2":
   version "6.7.2"


### PR DESCRIPTION
**Font Awesome kit** je aktualizovaný na verziu 1.0.73, čím pribudli nové ikony **moon** a **sun-bright**. Zoznam ikon v `font-awesome-subset.yaml` sa doteraz udržiaval ručne a **odchýlil sa od reálneho obsahu kitu** — obsahoval staré FA5 aliasy namiesto aktuálnych FA6 názvov.

## Detaily
- Pridaný `scripts/sync-font-awesome-subset.js`, ktorý generuje `font-awesome-subset.yaml` priamo z metadát nainštalovaného kitu (`icons/metadata/icons.json`) — kit sám je kurátorovaný subset, yaml je teraz len jeho odvodený obraz
- Skript zapojený ako `prebuild` hook v `package.json`, takže sa spúšťa automaticky pri každom builde; pridaný aj manuálny alias `yarn sync-fa-subset`
- Zastarané FA5 aliasy nahradené aktuálnymi FA6 názvami (napr. `cog` → `gear`, `check-circle` → `circle-check`), upravené použitia v demo ukážkach `buttons.pug` a `cards.pug`
- Aktualizovaný Font Awesome kit na verziu 1.0.73