### PR TITLE
Opravená autentifikácia na Font Awesome registry v CI

### DIFF
--- a/.github/workflows/build-dist-pr.yml
+++ b/.github/workflows/build-dist-pr.yml
@@ -25,6 +25,14 @@ jobs:
           node-version: 20
           cache: yarn
 
+      - name: Configure Font Awesome registry auth
+        run: |
+          cat <<EOF > .npmrc
+          @awesome.me:registry=https://npm.fontawesome.com/
+          @fortawesome:registry=https://npm.fontawesome.com/
+          //npm.fontawesome.com/:_authToken=${{ secrets.FONTAWESOME_NPM_TOKEN }}
+          EOF
+
       - run: yarn install
       - run: yarn prepare --openssl-legacy-provider
       - run: yarn build

--- a/.github/workflows/build-dist-pr.yml
+++ b/.github/workflows/build-dist-pr.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
 
       - name: Configure Font Awesome registry auth

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - run: yarn install
       - run: yarn test

--- a/.npmrc.example
+++ b/.npmrc.example
@@ -1,0 +1,9 @@
+; Copy this file to .npmrc (gitignored, never commit the real token) and
+; replace YOUR_FONTAWESOME_TOKEN_HERE with the Font Awesome Kit npm auth
+; token (ask a teammate / check the team password manager).
+;
+; This is required to install @fortawesome/* and @awesome.me/kit-* packages.
+
+@awesome.me:registry=https://npm.fontawesome.com/
+@fortawesome:registry=https://npm.fontawesome.com/
+//npm.fontawesome.com/:_authToken=YOUR_FONTAWESOME_TOKEN_HERE

--- a/npmrc.example
+++ b/npmrc.example
@@ -1,3 +1,0 @@
-@awesome.me:registry=https://npm.fontawesome.com/
-@fortawesome:registry=https://npm.fontawesome.com/
-//npm.fontawesome.com/:_authToken=


### PR DESCRIPTION
Prvý beh workflowu **"Build dist and open PR"** po merge PR #646 zlyhal na `401 Unauthorized` pri sťahovaní `@fortawesome`/`@awesome.me` balíčkov — `.npmrc` je zámerne v `.gitignore` (obsahuje tajný token), takže v čerstvom CI checkoute vôbec neexistuje.

## Detaily
- Workflow `build-dist-pr.yml` teraz pred `yarn install` vygeneruje `.npmrc` zo secretu `FONTAWESOME_NPM_TOKEN`
- Pridaný `.npmrc.example` (trackovaný v gite) ako vzor pre lokálny setup nových vývojárov, s placeholder tokenom

## Test plan
- [x] Pridať repo secret `FONTAWESOME_NPM_TOKEN` (Settings → Secrets and variables → Actions) s hodnotou z lokálneho `.npmrc`
- [ ] Po merge overiť, že workflow beh na `master` prejde a otvorí/aktualizuje PR s `dist/`