### PR TITLE
Opravená nekonečná slučka v build-dist-pr workflowe

### DIFF
--- a/.github/workflows/build-dist-pr.yml
+++ b/.github/workflows/build-dist-pr.yml
@@ -3,6 +3,11 @@ name: Build dist and open PR
 on:
   push:
     branches: [master]
+    # A push that only touches dist/ is the bot's own build-artifact commit
+    # (or a merge of its PR) — skip it, or every merge would trigger another
+    # build and re-open this same PR forever.
+    paths-ignore:
+      - 'dist/**'
 
 # Avoid two builds racing to push the same branch if master gets multiple
 # quick pushes (e.g. a merge queue).


### PR DESCRIPTION
Časť tohto repa generuje náhodné hodnoty priamo pri renderovaní (napr. `Math.random()` pre poradie obrázkov v `campaign-2024-auth.pug`, ID sliderov/kariet naprieč viacerými view a mixin súbormi) — produkčný build je preto **principiálne nedeterministický**. Po merge bot PR-u s `dist/` sa spustil ten istý workflow znova, nový build sa opäť líšil a donekonečna sa otváral ďalší PR (#648 → #649 → ...).

## Detaily
- Pridaný `paths-ignore: dist/**` na push trigger v `build-dist-pr.yml`
- Push, ktorý mení iba `dist/` (merge bot PR-u), workflow už nespustí — slučka sa preruší
- Reálna zmena zdrojov v `app/` (alebo inde mimo `dist/`) build naďalej spustí normálne

## Test plan
- [ ] Po merge overiť, že zmergovanie visiaceho PR #649 (dist/) už nevytvorí ďalší build PR